### PR TITLE
feat: OpenFeature::SDK.configure

### DIFF
--- a/lib/openfeature/sdk.rb
+++ b/lib/openfeature/sdk.rb
@@ -7,7 +7,6 @@ module OpenFeature
   # TODO: Add documentation
   #
   module SDK
-
     class << self
       def method_missing(method_name, *args, **kwargs, &block)
         if API.instance.respond_to?(method_name)
@@ -21,6 +20,5 @@ module OpenFeature
         API.instance.respond_to?(method_name, include_private) || super
       end
     end
-
   end
 end

--- a/lib/openfeature/sdk.rb
+++ b/lib/openfeature/sdk.rb
@@ -7,5 +7,20 @@ module OpenFeature
   # TODO: Add documentation
   #
   module SDK
+
+    class << self
+      def method_missing(method_name, *args, **kwargs, &block)
+        if API.instance.respond_to?(method_name)
+          API.instance.send(method_name, *args, **kwargs, &block)
+        else
+          super
+        end
+      end
+
+      def respond_to_missing?(method_name, include_private = false)
+        API.instance.respond_to?(method_name, include_private) || super
+      end
+    end
+
   end
 end

--- a/spec/openfeature/sdk_spec.rb
+++ b/spec/openfeature/sdk_spec.rb
@@ -4,4 +4,12 @@ RSpec.describe OpenFeature::SDK do
   it "has a version number" do
     expect(OpenFeature::SDK::VERSION).not_to be_nil
   end
+
+  it "can be configured" do
+    expect(OpenFeature::SDK).to respond_to(:configure)
+
+    OpenFeature::SDK.configure do |config|
+      # don't test here, rely on OpenFeature::SDK::API instead
+    end
+  end
 end


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This adds the `OpenFeature::SDK.configure` method listed in README.md

All the functionality is already implemented in `OpenFeature::SDK::API`, so this just delegates to it using `method_missing`. And it's sibling `respond_to_missing?`

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

https://github.com/open-feature/ruby-sdk/pull/40 which helps point out what we're missing from an initial implementation

### Notes
<!-- any additional notes for this PR -->

I am kinda wondering if there's value in splitting out `OpenFeature::SDK::API` vs `OpenFeature::SDK`. I went with what was easiest for now.

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

