### PR TITLE
test: restructure some specs to make requirements the top level conte…

### DIFF
--- a/spec/openfeature/sdk/api_spec.rb
+++ b/spec/openfeature/sdk/api_spec.rb
@@ -11,6 +11,10 @@ require "openfeature/sdk/metadata"
 RSpec.describe OpenFeature::SDK::API do
   subject(:api) { described_class.instance }
 
+  context "with Requirement 1.1.1" do
+    pending
+  end
+
   context "with Requirement 1.1.2" do
     before do
       api.configure do |config|
@@ -89,5 +93,9 @@ RSpec.describe OpenFeature::SDK::API do
     it do
       expect(api).is_a?(OpenFeature::SDK::Client)
     end
+  end
+
+  context "with Requirement 1.1.6" do
+    pending
   end
 end

--- a/spec/openfeature/sdk/client_spec.rb
+++ b/spec/openfeature/sdk/client_spec.rb
@@ -93,11 +93,15 @@ RSpec.describe OpenFeature::SDK::Client do
       end
     end
 
-    context "Requirement 1.4.1" do
-      context "MUST provide methods for detailed flag value evaluation with parameters flag key (string, required), default value (boolean | number | string | structure, required), evaluation context (optional), and evaluation options (optional), which returns an evaluation details structure." do
-        let(:flag_key) { "my-awesome-feature-flag-key" }
+    context "Requirement 1.3.3" do
+      pending
+    end
 
-        context "boolean value" do
+    context "Detailed Feature Evaluation" do
+      let(:flag_key) { "my-awesome-feature-flag-key" }
+
+      context "boolean value" do
+        context "Requirement 1.4.1" do
           it do
             expect(client).to respond_to(:fetch_boolean_details)
           end
@@ -105,22 +109,32 @@ RSpec.describe OpenFeature::SDK::Client do
           it do
             expect(client.fetch_boolean_details(flag_key: flag_key, default_value: false)).is_a?(OpenFeature::SDK::Provider::NoOpProvider::ResolutionDetails)
           end
+        end
 
-          context "Requirement 1.4.2" do
-            it "The evaluation details structure's value field MUST contain the evaluated flag value" do
-              expect(client.fetch_boolean_details(flag_key: flag_key, default_value: true).value).is_a?(TrueClass)
-              expect(client.fetch_boolean_details(flag_key: flag_key, default_value: false).value).is_a?(FalseClass)
-            end
-          end
-
-          context "Requirement 1.4.4" do
-            it "The evaluation details structure's flag key field MUST contain the flag key argument passed to the detailed flag evaluation method." do
-              expect(client).to respond_to(:fetch_boolean_details)
-            end
+        context "Requirement 1.4.2" do
+          it "The evaluation details structure's value field MUST contain the evaluated flag value" do
+            expect(client.fetch_boolean_details(flag_key: flag_key, default_value: true).value).is_a?(TrueClass)
+            expect(client.fetch_boolean_details(flag_key: flag_key, default_value: false).value).is_a?(FalseClass)
           end
         end
 
-        context "number value" do
+        context "Requirement 1.4.3" do
+          pending
+        end
+
+        context "Requirement 1.4.4" do
+          it "The evaluation details structure's flag key field MUST contain the flag key argument passed to the detailed flag evaluation method." do
+            expect(client).to respond_to(:fetch_boolean_details)
+          end
+        end
+
+        context "Requirement 1.4.5" do
+          pending
+        end
+      end
+
+      context "number value" do
+        context "Requirement 1.4.1" do
           it do
             expect(client).to respond_to(:fetch_number_details)
           end
@@ -129,22 +143,28 @@ RSpec.describe OpenFeature::SDK::Client do
             expect(client.fetch_number_details(flag_key: flag_key, default_value: 1.2)).is_a?(OpenFeature::SDK::Provider::NoOpProvider::ResolutionDetails)
             expect(client.fetch_number_details(flag_key: flag_key, default_value: 1)).is_a?(OpenFeature::SDK::Provider::NoOpProvider::ResolutionDetails)
           end
+        end
 
-          context "Requirement 1.4.2" do
-            it "The evaluation details structure's value field MUST contain the evaluated flag value" do
-              expect(client.fetch_number_details(flag_key: flag_key, default_value: 1.0).value).is_a?(Float)
-              expect(client.fetch_number_details(flag_key: flag_key, default_value: 1).value).is_a?(Integer)
-            end
-          end
-
-          context "Requirement 1.4.4" do
-            it "The evaluation details structure's flag key field MUST contain the flag key argument passed to the detailed flag evaluation method." do
-              expect(client).to respond_to(:fetch_number_details)
-            end
+        context "Requirement 1.4.2" do
+          it "The evaluation details structure's value field MUST contain the evaluated flag value" do
+            expect(client.fetch_number_details(flag_key: flag_key, default_value: 1.0).value).is_a?(Float)
+            expect(client.fetch_number_details(flag_key: flag_key, default_value: 1).value).is_a?(Integer)
           end
         end
 
-        context "string value" do
+        context "Requirement 1.4.3" do
+          pending
+        end
+
+        context "Requirement 1.4.4" do
+          it "The evaluation details structure's flag key field MUST contain the flag key argument passed to the detailed flag evaluation method." do
+            expect(client).to respond_to(:fetch_number_details)
+          end
+        end
+      end
+
+      context "string value" do
+        context "Requirement 1.4.1" do
           it do
             expect(client).to respond_to(:fetch_string_details)
           end
@@ -152,21 +172,27 @@ RSpec.describe OpenFeature::SDK::Client do
           it do
             expect(client.fetch_string_details(flag_key: flag_key, default_value: "some-string")).is_a?(OpenFeature::SDK::Provider::NoOpProvider::ResolutionDetails)
           end
+        end
 
-          context "Requirement 1.4.2" do
-            it "The evaluation details structure's value field MUST contain the evaluated flag value" do
-              expect(client.fetch_string_details(flag_key: flag_key, default_value: "some-string").value).is_a?(String)
-            end
-          end
-
-          context "Requirement 1.4.4" do
-            it "The evaluation details structure's flag key field MUST contain the flag key argument passed to the detailed flag evaluation method." do
-              expect(client).to respond_to(:fetch_string_details)
-            end
+        context "Requirement 1.4.2" do
+          it "The evaluation details structure's value field MUST contain the evaluated flag value" do
+            expect(client.fetch_string_details(flag_key: flag_key, default_value: "some-string").value).is_a?(String)
           end
         end
 
-        context "object value" do
+        context "Requirement 1.4.3" do
+          pending
+        end
+
+        context "Requirement 1.4.4" do
+          it "The evaluation details structure's flag key field MUST contain the flag key argument passed to the detailed flag evaluation method." do
+            expect(client).to respond_to(:fetch_string_details)
+          end
+        end
+      end
+
+      context "object value" do
+        context "Requirement 1.4.1" do
           it do
             expect(client).to respond_to(:fetch_object_details)
           end
@@ -175,20 +201,58 @@ RSpec.describe OpenFeature::SDK::Client do
             expect(client.fetch_object_details(flag_key: flag_key,
                                                default_value: { name: "some-name" })).is_a?(OpenFeature::SDK::Provider::NoOpProvider::ResolutionDetails)
           end
+        end
 
-          context "Requirement 1.4.2" do
-            it "The evaluation details structure's value field MUST contain the evaluated flag value" do
-              expect(client.fetch_object_details(flag_key: flag_key,
-                                                 default_value: { name: "some-name" }).value).is_a?(String)
-            end
-          end
-
-          context "Requirement 1.4.4" do
-            it "The evaluation details structure's flag key field MUST contain the flag key argument passed to the detailed flag evaluation method." do
-              expect(client).to respond_to(:fetch_object_details)
-            end
+        context "Requirement 1.4.2" do
+          it "The evaluation details structure's value field MUST contain the evaluated flag value" do
+            expect(client.fetch_object_details(flag_key: flag_key,
+                                               default_value: { name: "some-name" }).value).is_a?(String)
           end
         end
+
+        context "Requirement 1.4.4" do
+          it "The evaluation details structure's flag key field MUST contain the flag key argument passed to the detailed flag evaluation method." do
+            expect(client).to respond_to(:fetch_object_details)
+          end
+        end
+      end
+
+      context "Requirement 1.4.5" do
+        pending
+      end
+
+      context "Requirement 1.4.6" do
+        pending
+      end
+
+      context "Requirement 1.4.7" do
+        pending
+      end
+
+      context "Requirement 1.4.8" do
+        pending
+      end
+
+      context "Requirement 1.4.9" do
+        pending
+      end
+
+      context "Requirement 1.4.10" do
+        pending
+      end
+
+      context "Requirement 1.4.11" do
+        pending
+      end
+
+      context "Requirement 1.4.12" do
+        pending
+      end
+    end
+
+    context "Evaluation Options" do
+      context "Requirement 1.5.1" do
+        pending
       end
     end
   end


### PR DESCRIPTION
…xt, and add pending contexts for ones not implemented/tested yet

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

I wanted to see what is left to implement, so I was going through the specs and comparing to https://docs.openfeature.dev/docs/specification/sections/flag-evaluation

In one case, there was a `Requirement x.y.z` context, that then had `Requirement x.y.z+1` nested under it. I restructured to have these requirements at the same depth.

Also added a few contexts for Requirements not yet implemented, or not tested.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

Look at CI results 🚦 