### PR TITLE
ci: update Ruby version matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ jobs:
           - "2.7"
           - "3.0"
           - "3.1"
+          - "3.2"
     env:
       BUNDLE_GEMFILE: Gemfile
 
@@ -36,7 +37,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: 3.2
       - run: bundle install
       - name: Rubocop
         run: bundle exec rubocop --color

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 name: CI
 
-on: push
+on:
+  - push
+  - pull_request
 
 jobs:
   rspec:

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ We support multiple data types for flags (numbers, strings, booleans, objects) a
 
 | Ruby Version | OS                          |
 | -----------  | -----------                 |
-| Ruby 2.7.6   | Windows, MacOS, Linux       |
-| Ruby 3.0.4   | Windows, MacOS, Linux       |
-| Ruby 3.1.2   | Windows, MacOS, Linux       |
+| Ruby 2.7.8   | Windows, MacOS, Linux       |
+| Ruby 3.0.6   | Windows, MacOS, Linux       |
+| Ruby 3.1.4   | Windows, MacOS, Linux       |
+| Ruby 3.2.2   | Windows, MacOS, Linux       |
 
 
 ## Installation

--- a/openfeature-sdk.gemspec
+++ b/openfeature-sdk.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "Ruby SDK for an the specifications for the open standard of feature flag management"
   spec.homepage = "https://github.com/open-feature/openfeature-ruby"
   spec.license = "Apache-2.0'"
-  spec.required_ruby_version = ">= 2.7.6"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/open-feature/openfeature-ruby"


### PR DESCRIPTION
## This PR

- Updates supported Ruby version matrix on README and tests against Ruby 3.2
- Loosens required Ruby version to any Ruby 2.7 version
- Updates main workflow trigger to include PRs (my fork was not triggering it because it was not a push event to the origin repository

### Notes

I went back and forth on removing Ruby 3.0 support as it entered security EoL. There's a compelling case to keep Ruby 2.7, as many organizations might be stuck there for a while, and it would be nice for them to have the OpenFeature SDK available. However, we might consider keeping only N+1 support for Ruby 3.X. Let me know your thoughts, and I can update accordingly!

### How to test

- CI checks should continue to pass

