### PR TITLE
fix: OpenFeature::SDK::Configuration uses concurrent-ruby gem even though it doesn't depend on it

### DIFF
--- a/lib/openfeature/sdk/configuration.rb
+++ b/lib/openfeature/sdk/configuration.rb
@@ -18,7 +18,7 @@ module OpenFeature
       def_delegator :@provider, :metadata
 
       def initialize
-        @hooks = Concurrent::Array.new([])
+        @hooks = []
       end
     end
   end


### PR DESCRIPTION


<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
I am surprised our specs are passing as is, because we don't have a dependency on concurrent-ruby currently.

I seemed to remember talking with @josecolella about this, and we decided to go with regular type Array for now. I was pretty sure we implemented that, but I guess not 🙃

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->


### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

