### PR TITLE
chore: reduce codecov volume

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,10 @@ jobs:
           # - macos-latest
           # - windows-latest
         ruby:
-          - "2.7"
-          - "3.0"
-          - "3.1"
           - "3.2"
+          - "3.1"
+          - "3.0"
+          - "2.7"
     env:
       BUNDLE_GEMFILE: Gemfile
 
@@ -33,6 +33,7 @@ jobs:
       - name: RSpec
         run: bundle exec rspec
       - name: Upload coverage to Codecov
+        if: ${{ strategy.job-index == 0 }} # only run codecov on first run
         uses: codecov/codecov-action@8e29a53ea65f98e97f4ad4594d355d8e8fd5bcfe
         with:
           fail_ci_if_error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,8 +34,9 @@ jobs:
         run: bundle exec rspec
       - name: Upload coverage to Codecov
         if: ${{ strategy.job-index == 0 }} # only run codecov on first run
-        uses: codecov/codecov-action@8e29a53ea65f98e97f4ad4594d355d8e8fd5bcfe
+        uses: codecov/codecov-action@c9e4b7326764720e2d95c3a9615d9e6ba7fc949f
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
           file: coverage/coverage.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,7 @@ jobs:
         uses: codecov/codecov-action@c9e4b7326764720e2d95c3a9615d9e6ba7fc949f
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          name: Ruby SDK
           fail_ci_if_error: true
           verbose: true
           file: coverage/coverage.xml


### PR DESCRIPTION
Remove codecov from test matrix to reduce API/upload calls. I believe this should stop or significantly reduce the errors we're seeing here.