### PR TITLE
chore: auto-merge renovate, add CODEOWNERS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,10 +34,9 @@ jobs:
         run: bundle exec rspec
       - name: Upload coverage to Codecov
         if: ${{ strategy.job-index == 0 }} # only run codecov on first run
-        uses: codecov/codecov-action@c9e4b7326764720e2d95c3a9615d9e6ba7fc949f
+        uses: codecov/codecov-action@845c445181131d954f0198d3d0f26242acc0376e
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          name: Ruby SDK
           fail_ci_if_error: true
           verbose: true
           file: coverage/coverage.xml

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence
+#
+# Managed by Peribolos: https://github.com/open-feature/community/blob/main/config/open-feature/sdk-ruby/workgroup.yaml
+#
+* @open-feature/sdk-ruby-maintainers

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
Trying to improve things with renovate (consistent with other repos), also adding CODEOWNERS.

For more background, see here: https://github.com/open-feature/ruby-sdk/pull/67