### PR TITLE
chore: Remove unused RBS file

### DIFF
--- a/sig/openfeature/sdk.rbs
+++ b/sig/openfeature/sdk.rbs
@@ -1,6 +1,0 @@
-module Openfeature
-  module Sdk
-    VERSION: String
-    # See the writing guide of rbs: https://github.com/ruby/rbs#guides
-  end
-end


### PR DESCRIPTION
## This PR

- Removes default RBS file that was scaffolded with the gem.

### Related Issues

Fixes #66 

