### PR TITLE
test: Clarify Requirement 1.1.1

### DIFF
--- a/spec/openfeature/sdk/api_spec.rb
+++ b/spec/openfeature/sdk/api_spec.rb
@@ -11,10 +11,6 @@ require "openfeature/sdk/metadata"
 RSpec.describe OpenFeature::SDK::API do
   subject(:api) { described_class.instance }
 
-  context "with Requirement 1.1.1" do
-    pending
-  end
-
   context "with Requirement 1.1.2" do
     before do
       api.configure do |config|

--- a/spec/specification/flag_evaluation_api_spec.rb
+++ b/spec/specification/flag_evaluation_api_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Flag Evaluation API" do
+  context "1.1 - API Initialization and Configuration" do
+    context "Requirement 1.1.1" do
+      specify "the API should exist as a global singleton" do
+        expect(OpenFeature::SDK::API).to include(Singleton)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## This PR
I've begun work on the Flag Evaluation API section of the OpenFeature specification. I decided to go from top to bottom (similar to the current unit tests) and ensure there hasn't been any spec drift from the original work done here. 

Additionally, I propose maintaining a separate `specification` set of RSpec tests that correspond 1 to 1 with the specification as written. Currently, we're doing this in line with the unit tests. Still, I foresee situations where we'll want to drive out behavior in unit tests that don't necessarily correspond to a requirement (or when multiple unit tests could satisfy a requirement). Freeing the unit tests of the responsibility of tracking spec compliance seems beneficial.

Finally, I _think_ 1.1.1 can be demonstrated

- Adds a new `specification` folder for tracking specification compliance
- Adds comment where we satisfy the requirement in the source code

### Follow-up Tasks
I am working on each requirement in the Flag Evaluation API from spec version 0.7.0 and will have PRs this week. 

### How to test
There is no change to current behavior; a passing RSpec suite should be sufficient.

