### PR TITLE
feat: Implement Requirement 1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ For complete documentation, visit: https://openfeature.dev/docs/category/concept
 
 ### Providers
 
-Providers are allowed to implement an `initialize` method that is invoked when they are set in the API. In order to avoid conflicting with the Ruby `initialize` method, this method should be named `init`. In addition, it should not accept any parameters and the return value is not used.
+Providers are allowed to implement an initialize method that is invoked when they are set in the API. In order to avoid conflicting with the Ruby `initialize` method, this method should be named `init`. In addition, it should not accept any parameters and the return value is not used.
+
+Providers are also allowed to implement a `shutdown` method that is invoked on a provider when a new provider is set. This should not accept any parameters and the return value is not used.
 
 For complete documentation on the Provider interface, visit: https://openfeature.dev/specification/sections/providers
 

--- a/README.md
+++ b/README.md
@@ -67,11 +67,27 @@ For complete documentation, visit: https://openfeature.dev/docs/category/concept
 
 ### Providers
 
-Providers are allowed to implement an initialize method that is invoked when they are set in the API. In order to avoid conflicting with the Ruby `initialize` method, this method should be named `init`. In addition, it should not accept any parameters and the return value is not used.
+Providers are the abstraction layer between OpenFeature and different flag management systems. Custom ones can easily be implemented.
 
-Providers are also allowed to implement a `shutdown` method that is invoked on a provider when a new provider is set. This should not accept any parameters and the return value is not used.
+The `NoOpProvider` is an example of a minimally functioning provider. For complete documentation on the Provider interface, visit: https://openfeature.dev/specification/sections/providers.
 
-For complete documentation on the Provider interface, visit: https://openfeature.dev/specification/sections/providers
+In addition to the `fetch_*` methods, providers can optionally implement lifecycle methods that are invoked when the underlying provider is switched out. For example:
+
+```ruby
+class MyProvider
+  def init
+    # Perform any initialization steps with flag management system here
+    # Return value is ignored
+  end
+
+  def shutdown
+    # Perform any shutdown/reclamation steps with flag management system here
+    # Return value is ignored
+  end
+end
+```
+
+**Note** The OpenFeature spec defines a lifecycle method called `initialize` to be called when a new provider is set. To avoid conflicting with the Ruby `initialize` method, this method should be named `init` when creating a provider.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ For complete documentation, visit: https://openfeature.dev/docs/category/concept
 
 ### Providers
 
-Providers are the abstraction layer between OpenFeature and different flag management systems. Custom ones can easily be implemented.
+Providers are the abstraction layer between OpenFeature and different flag management systems.
 
-The `NoOpProvider` is an example of a minimally functioning provider. For complete documentation on the Provider interface, visit: https://openfeature.dev/specification/sections/providers.
+The `NoOpProvider` is an example of a minimalist provider. For complete documentation on the Provider interface, visit: https://openfeature.dev/specification/sections/providers.
 
 In addition to the `fetch_*` methods, providers can optionally implement lifecycle methods that are invoked when the underlying provider is switched out. For example:
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ object = client.fetch_object_value(flag_key: 'object_value', default_value: JSON
 
 For complete documentation, visit: https://openfeature.dev/docs/category/concepts
 
+### Providers
+
+Providers are allowed to implement an `initialize` method that is invoked when they are set in the API. In order to avoid conflicting with the Ruby `initialize` method, this method should be named `init`. In addition, it should not accept any parameters and the return value is not used.
+
+For complete documentation on the Provider interface, visit: https://openfeature.dev/specification/sections/providers
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to the OpenFeature project.

--- a/lib/open_feature/sdk/api.rb
+++ b/lib/open_feature/sdk/api.rb
@@ -30,7 +30,7 @@ module OpenFeature
       include Singleton # Satisfies Flag Evaluation API Requirement 1.1.1
       extend Forwardable
 
-      def_delegators :configuration, :provider, :hooks, :context
+      def_delegators :configuration, :provider, :provider=, :hooks, :context
 
       def configuration
         @configuration ||= Configuration.new

--- a/lib/open_feature/sdk/api.rb
+++ b/lib/open_feature/sdk/api.rb
@@ -29,9 +29,7 @@ module OpenFeature
       include Singleton # Satisfies Flag Evaluation API Requirement 1.1.1
       extend Forwardable
 
-      def_delegator :@configuration, :provider
-      def_delegator :@configuration, :hooks
-      def_delegator :@configuration, :context
+      def_delegators :@configuration, :provider, :provider=, :hooks, :context
 
       def configuration
         @configuration ||= Configuration.new
@@ -41,14 +39,6 @@ module OpenFeature
         return unless block
 
         block.call(configuration)
-      end
-
-      def set_provider(provider) # rubocop:disable Naming/AccessorMethodName
-        configuration.provider.shutdown if configuration&.provider.respond_to?(:shutdown)
-
-        provider.init if provider.respond_to?(:init)
-
-        configuration.provider = provider
       end
 
       def build_client(name: nil, version: nil)

--- a/lib/open_feature/sdk/api.rb
+++ b/lib/open_feature/sdk/api.rb
@@ -43,6 +43,10 @@ module OpenFeature
         block.call(configuration)
       end
 
+      def set_provider(provider) # rubocop:disable Naming/AccessorMethodName
+        configuration.provider = provider
+      end
+
       def build_client(name: nil, version: nil)
         client_options = Metadata.new(name: name, version: version).freeze
         provider = Provider::NoOpProvider.new if provider.nil?

--- a/lib/open_feature/sdk/api.rb
+++ b/lib/open_feature/sdk/api.rb
@@ -44,7 +44,10 @@ module OpenFeature
       end
 
       def set_provider(provider) # rubocop:disable Naming/AccessorMethodName
+        configuration.provider.shutdown if configuration&.provider.respond_to?(:shutdown)
+
         provider.init if provider.respond_to?(:init)
+
         configuration.provider = provider
       end
 

--- a/lib/open_feature/sdk/api.rb
+++ b/lib/open_feature/sdk/api.rb
@@ -26,7 +26,7 @@ module OpenFeature
     #
     #   client = OpenFeature::SDK::API.instance.build_client(name: 'my-open-feature-client')
     class API
-      include Singleton
+      include Singleton # Satisfies Flag Evaluation API Requirement 1.1.1
       extend Forwardable
 
       def_delegator :@configuration, :provider

--- a/lib/open_feature/sdk/api.rb
+++ b/lib/open_feature/sdk/api.rb
@@ -44,6 +44,7 @@ module OpenFeature
       end
 
       def set_provider(provider) # rubocop:disable Naming/AccessorMethodName
+        provider.init if provider.respond_to?(:init)
         configuration.provider = provider
       end
 

--- a/lib/open_feature/sdk/configuration.rb
+++ b/lib/open_feature/sdk/configuration.rb
@@ -13,12 +13,21 @@ module OpenFeature
     class Configuration
       extend Forwardable
 
-      attr_accessor :context, :provider, :hooks
+      attr_accessor :context, :hooks
+      attr_reader :provider
 
       def_delegator :@provider, :metadata
 
       def initialize
         @hooks = []
+      end
+
+      def provider=(provider)
+        @provider.shutdown if @provider.respond_to?(:shutdown)
+
+        provider.init if provider.respond_to?(:init)
+
+        @provider = provider
       end
     end
   end

--- a/lib/open_feature/sdk/configuration.rb
+++ b/lib/open_feature/sdk/configuration.rb
@@ -27,7 +27,7 @@ module OpenFeature
       #   2. On the new provider, call `init`.
       #   3. Finally, set the internal provider to the new provider
       def provider=(provider)
-        @provider.shutdown if !@provider.nil? && @provider.respond_to?(:shutdown)
+        @provider.shutdown if @provider.respond_to?(:shutdown)
 
         provider.init if provider.respond_to?(:init)
 

--- a/lib/open_feature/sdk/configuration.rb
+++ b/lib/open_feature/sdk/configuration.rb
@@ -22,8 +22,12 @@ module OpenFeature
         @hooks = []
       end
 
+      # When switching providers, there are a few lifecycle methods that need to be taken care of.
+      #   1. If a provider is already set, we need to call `shutdown` on it.
+      #   2. On the new provider, call `init`.
+      #   3. Finally, set the internal provider to the new provider
       def provider=(provider)
-        @provider.shutdown if @provider.respond_to?(:shutdown)
+        @provider.shutdown if !@provider.nil? && @provider.respond_to?(:shutdown)
 
         provider.init if provider.respond_to?(:init)
 

--- a/spec/open_feature/sdk/api_spec.rb
+++ b/spec/open_feature/sdk/api_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require_relative "../../support/test_provider"
 
 # https://openfeature.dev/docs/specification/sections/flag-evaluation#11-api-initialization-and-configuration
 
@@ -8,12 +9,26 @@ RSpec.describe OpenFeature::SDK::API do
   subject(:api) { described_class.instance }
 
   describe "#set_provider" do
-    it "accepts provider" do
-      provider = OpenFeature::SDK::Provider::NoOpProvider.new
+    context "when provider has an init method" do
+      let(:provider) { TestProvider.new }
 
-      api.set_provider(provider)
+      it "inits and sets the provider" do
+        expect(provider).to receive(:init)
 
-      expect(api.provider).to be(provider)
+        api.set_provider(provider)
+
+        expect(api.provider).to be(provider)
+      end
+    end
+
+    context "when provider does not have an init method" do
+      it "sets the provider" do
+        provider = OpenFeature::SDK::Provider::NoOpProvider.new
+
+        api.set_provider(provider)
+
+        expect(api.provider).to be(provider)
+      end
     end
   end
 

--- a/spec/open_feature/sdk/api_spec.rb
+++ b/spec/open_feature/sdk/api_spec.rb
@@ -1,36 +1,11 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "../../support/test_provider"
 
 # https://openfeature.dev/docs/specification/sections/flag-evaluation#11-api-initialization-and-configuration
 
 RSpec.describe OpenFeature::SDK::API do
   subject(:api) { described_class.instance }
-
-  describe "#set_provider" do
-    context "when provider has an init method" do
-      let(:provider) { TestProvider.new }
-
-      it "inits and sets the provider" do
-        expect(provider).to receive(:init)
-
-        api.set_provider(provider)
-
-        expect(api.provider).to be(provider)
-      end
-    end
-
-    context "when provider does not have an init method" do
-      it "sets the provider" do
-        provider = OpenFeature::SDK::Provider::NoOpProvider.new
-
-        api.set_provider(provider)
-
-        expect(api.provider).to be(provider)
-      end
-    end
-  end
 
   context "with Requirement 1.1.3" do
     before do

--- a/spec/open_feature/sdk/api_spec.rb
+++ b/spec/open_feature/sdk/api_spec.rb
@@ -7,23 +7,13 @@ require "spec_helper"
 RSpec.describe OpenFeature::SDK::API do
   subject(:api) { described_class.instance }
 
-  context "with Requirement 1.1.2" do
-    before do
-      api.configure do |config|
-        config.provider = OpenFeature::SDK::Provider::NoOpProvider.new
-      end
-    end
+  describe "#set_provider" do
+    it "accepts provider" do
+      provider = OpenFeature::SDK::Provider::NoOpProvider.new
 
-    it do
-      expect(api).to respond_to(:provider)
-    end
+      api.set_provider(provider)
 
-    it do
-      expect(api.provider).not_to be_nil
-    end
-
-    it do
-      expect(api.provider).is_a?(OpenFeature::SDK::Provider)
+      expect(api.provider).to be(provider)
     end
   end
 

--- a/spec/open_feature/sdk/configuration_spec.rb
+++ b/spec/open_feature/sdk/configuration_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe OpenFeature::SDK::Configuration do
+  subject(:configuration) { described_class.new }
+
+  describe "#provider=" do
+    context "when provider has an init method" do
+      let(:provider) { TestProvider.new }
+
+      it "inits and sets the provider" do
+        expect(provider).to receive(:init)
+
+        configuration.provider = provider
+
+        expect(configuration.provider).to be(provider)
+      end
+    end
+
+    context "when provider does not have an init method" do
+      it "sets the provider" do
+        provider = OpenFeature::SDK::Provider::NoOpProvider.new
+
+        configuration.provider = provider
+
+        expect(configuration.provider).to be(provider)
+      end
+    end
+  end
+end

--- a/spec/specification/flag_evaluation_api_spec.rb
+++ b/spec/specification/flag_evaluation_api_spec.rb
@@ -19,5 +19,14 @@ RSpec.describe "Flag Evaluation API" do
         expect(OpenFeature::SDK.provider).to be(provider)
       end
     end
+
+    context "Requirement 1.1.2.2" do
+      specify "the provider mutator must invoke an initialize function on the provider" do
+        provider = double
+        expect(provider).to receive(:init)
+
+        OpenFeature::SDK.set_provider(provider)
+      end
+    end
   end
 end

--- a/spec/specification/flag_evaluation_api_spec.rb
+++ b/spec/specification/flag_evaluation_api_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require_relative "../support/test_provider"
 
 RSpec.describe "Flag Evaluation API" do
   context "1.1 - API Initialization and Configuration" do
@@ -22,10 +23,23 @@ RSpec.describe "Flag Evaluation API" do
 
     context "Requirement 1.1.2.2" do
       specify "the provider mutator must invoke an initialize function on the provider" do
-        provider = double
+        provider = TestProvider.new
         expect(provider).to receive(:init)
 
         OpenFeature::SDK.set_provider(provider)
+      end
+    end
+
+    context "Requirement 1.1.2.3" do
+      specify "the provider mutator must invoke a shutdown function on previously registered provider" do
+        previous_provider = TestProvider.new
+        new_provider = TestProvider.new
+
+        expect(previous_provider).to receive(:shutdown)
+        expect(new_provider).not_to receive(:shutdown)
+
+        OpenFeature::SDK.set_provider(previous_provider)
+        OpenFeature::SDK.set_provider(new_provider)
       end
     end
   end

--- a/spec/specification/flag_evaluation_api_spec.rb
+++ b/spec/specification/flag_evaluation_api_spec.rb
@@ -9,5 +9,15 @@ RSpec.describe "Flag Evaluation API" do
         expect(OpenFeature::SDK::API).to include(Singleton)
       end
     end
+
+    context "Requirement 1.1.2.1" do
+      specify "the API must define a provider mutator" do
+        provider = OpenFeature::SDK::Provider::NoOpProvider.new
+
+        OpenFeature::SDK.set_provider(provider)
+
+        expect(OpenFeature::SDK.provider).to be(provider)
+      end
+    end
   end
 end

--- a/spec/specification/flag_evaluation_api_spec.rb
+++ b/spec/specification/flag_evaluation_api_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Flag Evaluation API" do
       specify "the API must define a provider mutator" do
         provider = OpenFeature::SDK::Provider::NoOpProvider.new
 
-        OpenFeature::SDK.set_provider(provider)
+        OpenFeature::SDK.provider = provider
 
         expect(OpenFeature::SDK.provider).to be(provider)
       end
@@ -26,7 +26,7 @@ RSpec.describe "Flag Evaluation API" do
         provider = TestProvider.new
         expect(provider).to receive(:init)
 
-        OpenFeature::SDK.set_provider(provider)
+        OpenFeature::SDK.provider = provider
       end
     end
 
@@ -38,8 +38,8 @@ RSpec.describe "Flag Evaluation API" do
         expect(previous_provider).to receive(:shutdown)
         expect(new_provider).not_to receive(:shutdown)
 
-        OpenFeature::SDK.set_provider(previous_provider)
-        OpenFeature::SDK.set_provider(new_provider)
+        OpenFeature::SDK.provider = previous_provider
+        OpenFeature::SDK.provider = new_provider
       end
     end
   end

--- a/spec/support/test_provider.rb
+++ b/spec/support/test_provider.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
 class TestProvider
-  def init; end
+  def init
+  end
+
+  def shutdown
+  end
 end

--- a/spec/support/test_provider.rb
+++ b/spec/support/test_provider.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class TestProvider
+  def init; end
+end


### PR DESCRIPTION
## This PR
Note that this is built off of #77 and will not have that base commit if that commit is accepted.

- Updates README to mention that Providers can invoke an `init` and `shutdown` method. I believe we want to leave the default `initialize` behavior alone in Ruby to satisfy this requirement. This means someone can initialize a Provider instance (and use whatever construction logic there is) and define an `init` method invoked when the provider is set.
- For now, I'm choosing to overload the `provider` writer method on `Configuration` with the behavior required for this requirement. In the following Requirement, which introduced named providers, we should consider renaming this to `set_provider` or `register_provider` or something similar, as there will be an additional argument that would be an unexpected writer signature. That will be a breaking change and is not strictly required for this requirement, so I decided to defer that.

### Follow-up Tasks
I plan on continuing to implement the flag evaluation API in subsequent PRs.

### How to test
Ensure that providers can still be set while configuring OpenFeature. You can play around with a stub Provider that implements `init` and `shutdown` to verify those are also called as expected.