### PR TITLE
feat!: Implement Requirement 1.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ require 'json' # For JSON.dump
 OpenFeature::SDK.configure do |config|
   # your provider of choice, which will be used as the default provider
   config.set_provider(OpenFeature::SDK::Provider::NoOpProvider.new)
-  # alternatively, you can bind multiple providers to different names
-  config.set_provider(OpenFeature::SDK::Provider::NoOpProvider.new, name: "legacy_flags")
+  # alternatively, you can bind multiple providers to different domains
+  config.set_provider(OpenFeature::SDK::Provider::NoOpProvider.new, domain: "legacy_flags")
 end
 
 # Create a client

--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ require 'json' # For JSON.dump
 # API Initialization and configuration
 
 OpenFeature::SDK.configure do |config|
-    # your provider of choice
-    config.set_provider(OpenFeature::SDK::Provider::NoOpProvider.new)
+  # your provider of choice, which will be used as the default provider
+  config.set_provider(OpenFeature::SDK::Provider::NoOpProvider.new)
+  # alternatively, you can bind multiple providers to different names
+  config.set_provider(OpenFeature::SDK::Provider::NoOpProvider.new, name: "legacy_flags")
 end
 
 # Create a client

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ require 'json' # For JSON.dump
 
 OpenFeature::SDK.configure do |config|
   # your provider of choice, which will be used as the default provider
-  config.provider = OpenFeature::SDK::Provider::InMemoryProvider.new(
+  config.set_provider(OpenFeature::SDK::Provider::InMemoryProvider.new(
     {
       "flag1" => true,
       "flag2" => 1
     }
-  )
+  ))
   # alternatively, you can bind multiple providers to different domains
   config.set_provider(OpenFeature::SDK::Provider::NoOpProvider.new, domain: "legacy_flags")
 end

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ require 'json' # For JSON.dump
 
 OpenFeature::SDK.configure do |config|
     # your provider of choice
-    config.provider = OpenFeature::SDK::Provider::NoOpProvider.new
+    config.set_provider(OpenFeature::SDK::Provider::NoOpProvider.new)
 end
 
 # Create a client

--- a/lib/open_feature/sdk/api.rb
+++ b/lib/open_feature/sdk/api.rb
@@ -42,6 +42,10 @@ module OpenFeature
         block.call(configuration)
       end
 
+      def set_provider(provider) # rubocop:disable Naming/AccessorMethodName
+        configuration.provider = provider
+      end
+
       def build_client(name: nil, version: nil)
         client_options = Metadata.new(name: name, version: version).freeze
         provider = Provider::NoOpProvider.new if provider.nil?

--- a/lib/open_feature/sdk/api.rb
+++ b/lib/open_feature/sdk/api.rb
@@ -43,7 +43,10 @@ module OpenFeature
       end
 
       def set_provider(provider) # rubocop:disable Naming/AccessorMethodName
+        configuration.provider.shutdown if configuration&.provider.respond_to?(:shutdown)
+
         provider.init if provider.respond_to?(:init)
+
         configuration.provider = provider
       end
 

--- a/lib/open_feature/sdk/api.rb
+++ b/lib/open_feature/sdk/api.rb
@@ -30,7 +30,7 @@ module OpenFeature
       include Singleton # Satisfies Flag Evaluation API Requirement 1.1.1
       extend Forwardable
 
-      def_delegators :@configuration, :provider, :set_provider, :hooks, :context
+      def_delegators :configuration, :provider, :set_provider, :hooks, :context
 
       def configuration
         @configuration ||= Configuration.new

--- a/lib/open_feature/sdk/api.rb
+++ b/lib/open_feature/sdk/api.rb
@@ -19,7 +19,7 @@ module OpenFeature
     # To use the SDK, you can optionally configure a <tt>Provider</tt>, with <tt>Hook</tt>
     #
     #   OpenFeature::SDK::API.instance.configure do |config|
-    #     config.provider = NoOpProvider.new
+    #     config.set_provider NoOpProvider.new
     #   end
     #
     # If no provider is specified, the <tt>NoOpProvider</tt> is set as the default <tt>Provider</tt>.

--- a/lib/open_feature/sdk/api.rb
+++ b/lib/open_feature/sdk/api.rb
@@ -30,7 +30,7 @@ module OpenFeature
       include Singleton # Satisfies Flag Evaluation API Requirement 1.1.1
       extend Forwardable
 
-      def_delegators :configuration, :provider, :provider=, :hooks, :context
+      def_delegators :@configuration, :provider, :set_provider, :hooks, :context
 
       def configuration
         @configuration ||= Configuration.new
@@ -40,14 +40,6 @@ module OpenFeature
         return unless block
 
         block.call(configuration)
-      end
-
-      def set_provider(provider) # rubocop:disable Naming/AccessorMethodName
-        configuration.provider.shutdown if configuration&.provider.respond_to?(:shutdown)
-
-        provider.init if provider.respond_to?(:init)
-
-        configuration.provider = provider
       end
 
       def build_client(name: nil, version: nil)

--- a/lib/open_feature/sdk/api.rb
+++ b/lib/open_feature/sdk/api.rb
@@ -43,6 +43,7 @@ module OpenFeature
       end
 
       def set_provider(provider) # rubocop:disable Naming/AccessorMethodName
+        provider.init if provider.respond_to?(:init)
         configuration.provider = provider
       end
 

--- a/lib/open_feature/sdk/configuration.rb
+++ b/lib/open_feature/sdk/configuration.rb
@@ -22,20 +22,20 @@ module OpenFeature
         @providers = {}
       end
 
-      def provider
-        @providers[nil]
+      def provider(name: nil)
+        @providers[name]
       end
 
-      # When switching providers, there are a few lifecycle methods that need to be taken care of.
+	  # When switching providers, there are a few lifecycle methods that need to be taken care of.
       #   1. If a provider is already set, we need to call `shutdown` on it.
       #   2. On the new provider, call `init`.
       #   3. Finally, set the internal provider to the new provider
-      def set_provider(provider)
-        @providers[nil].shutdown if @providers[nil].respond_to?(:shutdown)
+      def set_provider(provider, name: nil)
+        @providers[name].shutdown if @providers[name].respond_to?(:shutdown)
 
         provider.init if provider.respond_to?(:init)
 
-        @providers[nil] = provider
+        @providers[name] = provider
       end
     end
   end

--- a/lib/open_feature/sdk/configuration.rb
+++ b/lib/open_feature/sdk/configuration.rb
@@ -26,7 +26,7 @@ module OpenFeature
       #   1. If a provider is already set, we need to call `shutdown` on it.
       #   2. On the new provider, call `init`.
       #   3. Finally, set the internal provider to the new provider
-      def provider=(provider)
+      def set_provider(provider)
         @provider.shutdown if @provider.respond_to?(:shutdown)
 
         provider.init if provider.respond_to?(:init)

--- a/lib/open_feature/sdk/configuration.rb
+++ b/lib/open_feature/sdk/configuration.rb
@@ -14,12 +14,16 @@ module OpenFeature
       extend Forwardable
 
       attr_accessor :context, :hooks
-      attr_reader :provider
 
-      def_delegator :@provider, :metadata
+      def_delegator :provider, :metadata
 
       def initialize
         @hooks = []
+        @providers = {}
+      end
+
+      def provider
+        @providers[nil]
       end
 
       # When switching providers, there are a few lifecycle methods that need to be taken care of.
@@ -27,11 +31,11 @@ module OpenFeature
       #   2. On the new provider, call `init`.
       #   3. Finally, set the internal provider to the new provider
       def set_provider(provider)
-        @provider.shutdown if @provider.respond_to?(:shutdown)
+        @providers[nil].shutdown if @providers[nil].respond_to?(:shutdown)
 
         provider.init if provider.respond_to?(:init)
 
-        @provider = provider
+        @providers[nil] = provider
       end
     end
   end

--- a/lib/open_feature/sdk/configuration.rb
+++ b/lib/open_feature/sdk/configuration.rb
@@ -22,20 +22,20 @@ module OpenFeature
         @providers = {}
       end
 
-      def provider(name: nil)
-        @providers[name]
+      def provider(domain: nil)
+        @providers[domain]
       end
 
       # When switching providers, there are a few lifecycle methods that need to be taken care of.
       #   1. If a provider is already set, we need to call `shutdown` on it.
       #   2. On the new provider, call `init`.
       #   3. Finally, set the internal provider to the new provider
-      def set_provider(provider, name: nil)
-        @providers[name].shutdown if @providers[name].respond_to?(:shutdown)
+      def set_provider(provider, domain: nil)
+        @providers[domain].shutdown if @providers[domain].respond_to?(:shutdown)
 
         provider.init if provider.respond_to?(:init)
 
-        @providers[name] = provider
+        @providers[domain] = provider
       end
     end
   end

--- a/lib/open_feature/sdk/configuration.rb
+++ b/lib/open_feature/sdk/configuration.rb
@@ -26,7 +26,7 @@ module OpenFeature
         @providers[name]
       end
 
-	  # When switching providers, there are a few lifecycle methods that need to be taken care of.
+      # When switching providers, there are a few lifecycle methods that need to be taken care of.
       #   1. If a provider is already set, we need to call `shutdown` on it.
       #   2. On the new provider, call `init`.
       #   3. Finally, set the internal provider to the new provider

--- a/lib/open_feature/sdk/provider/no_op_provider.rb
+++ b/lib/open_feature/sdk/provider/no_op_provider.rb
@@ -11,7 +11,7 @@ module OpenFeature
       # To use <tt>NoOpProvider</tt>, it can be set during the configuration of the SDK
       #
       #   OpenFeature::SDK.configure do |config|
-      #     config.provider = NoOpProvider.new
+      #     config.set_provider NoOpProvider.new
       #   end
       #
       # Within the <tt>NoOpProvider</tt>, the following methods exist

--- a/spec/open_feature/sdk/api_spec.rb
+++ b/spec/open_feature/sdk/api_spec.rb
@@ -7,30 +7,6 @@ require "spec_helper"
 RSpec.describe OpenFeature::SDK::API do
   subject(:api) { described_class.instance }
 
-  describe "#set_provider" do
-    context "when provider has an init method" do
-      let(:provider) { TestProvider.new }
-
-      it "inits and sets the provider" do
-        expect(provider).to receive(:init)
-
-        api.set_provider(provider)
-
-        expect(api.provider).to be(provider)
-      end
-    end
-
-    context "when provider does not have an init method" do
-      it "sets the provider" do
-        provider = OpenFeature::SDK::Provider::NoOpProvider.new
-
-        api.set_provider(provider)
-
-        expect(api.provider).to be(provider)
-      end
-    end
-  end
-
   context "with Requirement 1.1.3" do
     before do
       api.configure do |config|

--- a/spec/open_feature/sdk/api_spec.rb
+++ b/spec/open_feature/sdk/api_spec.rb
@@ -7,6 +7,16 @@ require "spec_helper"
 RSpec.describe OpenFeature::SDK::API do
   subject(:api) { described_class.instance }
 
+  describe "#set_provider" do
+    it "accepts provider" do
+      provider = OpenFeature::SDK::Provider::NoOpProvider.new
+
+      api.set_provider(provider)
+
+      expect(api.provider).to be(provider)
+    end
+  end
+
   context "with Requirement 1.1.3" do
     before do
       api.configure do |config|

--- a/spec/open_feature/sdk/api_spec.rb
+++ b/spec/open_feature/sdk/api_spec.rb
@@ -8,12 +8,26 @@ RSpec.describe OpenFeature::SDK::API do
   subject(:api) { described_class.instance }
 
   describe "#set_provider" do
-    it "accepts provider" do
-      provider = OpenFeature::SDK::Provider::NoOpProvider.new
+    context "when provider has an init method" do
+      let(:provider) { TestProvider.new }
 
-      api.set_provider(provider)
+      it "inits and sets the provider" do
+        expect(provider).to receive(:init)
 
-      expect(api.provider).to be(provider)
+        api.set_provider(provider)
+
+        expect(api.provider).to be(provider)
+      end
+    end
+
+    context "when provider does not have an init method" do
+      it "sets the provider" do
+        provider = OpenFeature::SDK::Provider::NoOpProvider.new
+
+        api.set_provider(provider)
+
+        expect(api.provider).to be(provider)
+      end
     end
   end
 

--- a/spec/open_feature/sdk/api_spec.rb
+++ b/spec/open_feature/sdk/api_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe OpenFeature::SDK::API do
   context "with Requirement 1.1.3" do
     before do
       api.configure do |config|
-        config.provider = OpenFeature::SDK::Provider::NoOpProvider.new
+        config.set_provider(OpenFeature::SDK::Provider::NoOpProvider.new)
         config.hooks << hook1
         config.hooks << hook2
       end
@@ -28,7 +28,7 @@ RSpec.describe OpenFeature::SDK::API do
   context "with Requirement 1.1.4" do
     before do
       api.configure do |config|
-        config.provider = OpenFeature::SDK::Provider::NoOpProvider.new
+        config.set_provider(OpenFeature::SDK::Provider::NoOpProvider.new)
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.describe OpenFeature::SDK::API do
   context "with Requirement 1.1.5" do
     before do
       api.configure do |config|
-        config.provider = OpenFeature::SDK::Provider::NoOpProvider.new
+        config.set_provider(OpenFeature::SDK::Provider::NoOpProvider.new)
       end
 
       api.build_client(name: "requirement-1.1.5")

--- a/spec/open_feature/sdk/configuration_spec.rb
+++ b/spec/open_feature/sdk/configuration_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe OpenFeature::SDK::Configuration do
       it "inits and sets the provider" do
         expect(provider).to receive(:init)
 
-        configuration.provider = provider
+        configuration.set_provider(provider)
 
         expect(configuration.provider).to be(provider)
       end
@@ -22,7 +22,7 @@ RSpec.describe OpenFeature::SDK::Configuration do
       it "sets the provider" do
         provider = OpenFeature::SDK::Provider::NoOpProvider.new
 
-        configuration.provider = provider
+        configuration.set_provider(provider)
 
         expect(configuration.provider).to be(provider)
       end

--- a/spec/open_feature/sdk/configuration_spec.rb
+++ b/spec/open_feature/sdk/configuration_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe OpenFeature::SDK::Configuration do
         provider = TestProvider.new
         expect(provider).to receive(:init)
 
-        configuration.set_provider(provider, name: "testing")
+        configuration.set_provider(provider, domain: "testing")
 
-        expect(configuration.provider(name: "testing")).to be(provider)
+        expect(configuration.provider(domain: "testing")).to be(provider)
       end
     end
   end

--- a/spec/open_feature/sdk/configuration_spec.rb
+++ b/spec/open_feature/sdk/configuration_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 RSpec.describe OpenFeature::SDK::Configuration do
   subject(:configuration) { described_class.new }
 
-  describe "#provider=" do
+  describe "#set_provider" do
     context "when provider has an init method" do
       let(:provider) { TestProvider.new }
 
@@ -19,12 +19,23 @@ RSpec.describe OpenFeature::SDK::Configuration do
     end
 
     context "when provider does not have an init method" do
-      it "sets the provider" do
+      it "sets the default provider" do
         provider = OpenFeature::SDK::Provider::NoOpProvider.new
 
         configuration.set_provider(provider)
 
         expect(configuration.provider).to be(provider)
+      end
+    end
+
+    context "when name is given" do
+      it "binds the provider to that name" do
+        provider = TestProvider.new
+        expect(provider).to receive(:init)
+
+        configuration.set_provider(provider, name: "testing")
+
+        expect(configuration.provider(name: "testing")).to be(provider)
       end
     end
   end

--- a/spec/open_feature/sdk/configuration_spec.rb
+++ b/spec/open_feature/sdk/configuration_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe OpenFeature::SDK::Configuration do
 
     context "when name is given" do
       it "binds the provider to that name" do
-        provider = TestProvider.new
+        provider = OpenFeature::SDK::Provider::InMemoryProvider.new
         expect(provider).to receive(:init)
 
         configuration.set_provider(provider, domain: "testing")

--- a/spec/specification/flag_evaluation_api_spec.rb
+++ b/spec/specification/flag_evaluation_api_spec.rb
@@ -23,10 +23,23 @@ RSpec.describe "Flag Evaluation API" do
 
     context "Requirement 1.1.2.2" do
       specify "the provider mutator must invoke an initialize function on the provider" do
-        provider = double
+        provider = TestProvider.new
         expect(provider).to receive(:init)
 
         OpenFeature::SDK.set_provider(provider)
+      end
+    end
+
+    context "Requirement 1.1.2.3" do
+      specify "the provider mutator must invoke a shutdown function on previously registered provider" do
+        previous_provider = TestProvider.new
+        new_provider = TestProvider.new
+
+        expect(previous_provider).to receive(:shutdown)
+        expect(new_provider).not_to receive(:shutdown)
+
+        OpenFeature::SDK.set_provider(previous_provider)
+        OpenFeature::SDK.set_provider(new_provider)
       end
     end
   end

--- a/spec/specification/flag_evaluation_api_spec.rb
+++ b/spec/specification/flag_evaluation_api_spec.rb
@@ -42,5 +42,29 @@ RSpec.describe "Flag Evaluation API" do
         OpenFeature::SDK.set_provider(new_provider)
       end
     end
+
+    context "Requirement 1.1.3" do
+      specify "the API must provide a function to bind a given provider to one or more client names" do
+        first_provider = TestProvider.new
+        second_provider = TestProvider.new
+
+        OpenFeature::SDK.set_provider(first_provider, name: "first")
+        OpenFeature::SDK.set_provider(second_provider, name: "second")
+
+        expect(OpenFeature::SDK.provider(name: "first")).to be(first_provider)
+        expect(OpenFeature::SDK.provider(name: "second")).to be(second_provider)
+      end
+
+      specify "if client name is already bound, it is overwritten" do
+        previous_provider = TestProvider.new
+        new_provider = TestProvider.new
+
+        OpenFeature::SDK.set_provider(previous_provider, name: "testing")
+        expect(OpenFeature::SDK.provider(name: "testing")).to be(previous_provider)
+
+        OpenFeature::SDK.set_provider(new_provider, name: "testing")
+        expect(OpenFeature::SDK.provider(name: "testing")).to be(new_provider)
+      end
+    end
   end
 end

--- a/spec/specification/flag_evaluation_api_spec.rb
+++ b/spec/specification/flag_evaluation_api_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Flag Evaluation API" do
       specify "the API must define a provider mutator" do
         provider = OpenFeature::SDK::Provider::NoOpProvider.new
 
-        OpenFeature::SDK.provider = provider
+        OpenFeature::SDK.set_provider(provider)
 
         expect(OpenFeature::SDK.provider).to be(provider)
       end
@@ -26,7 +26,7 @@ RSpec.describe "Flag Evaluation API" do
         provider = TestProvider.new
         expect(provider).to receive(:init)
 
-        OpenFeature::SDK.provider = provider
+        OpenFeature::SDK.set_provider(provider)
       end
     end
 
@@ -38,8 +38,8 @@ RSpec.describe "Flag Evaluation API" do
         expect(previous_provider).to receive(:shutdown)
         expect(new_provider).not_to receive(:shutdown)
 
-        OpenFeature::SDK.provider = previous_provider
-        OpenFeature::SDK.provider = new_provider
+        OpenFeature::SDK.set_provider(previous_provider)
+        OpenFeature::SDK.set_provider(new_provider)
       end
     end
   end

--- a/spec/specification/flag_evaluation_api_spec.rb
+++ b/spec/specification/flag_evaluation_api_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe "Flag Evaluation API" do
 
     context "Requirement 1.1.3" do
       specify "the API must provide a function to bind a given provider to one or more client names" do
-        first_provider = TestProvider.new
-        second_provider = TestProvider.new
+        first_provider = OpenFeature::SDK::Provider::InMemoryProvider.new
+        second_provider = OpenFeature::SDK::Provider::InMemoryProvider.new
 
         OpenFeature::SDK.set_provider(first_provider, domain: "first")
         OpenFeature::SDK.set_provider(second_provider, domain: "second")
@@ -55,8 +55,8 @@ RSpec.describe "Flag Evaluation API" do
       end
 
       specify "if client name is already bound, it is overwritten" do
-        previous_provider = TestProvider.new
-        new_provider = TestProvider.new
+        previous_provider = OpenFeature::SDK::Provider::InMemoryProvider.new
+        new_provider = OpenFeature::SDK::Provider::InMemoryProvider.new
 
         OpenFeature::SDK.set_provider(previous_provider, domain: "testing")
         expect(OpenFeature::SDK.provider(domain: "testing")).to be(previous_provider)

--- a/spec/specification/flag_evaluation_api_spec.rb
+++ b/spec/specification/flag_evaluation_api_spec.rb
@@ -15,31 +15,9 @@ RSpec.describe "Flag Evaluation API" do
       specify "the API must define a provider mutator" do
         provider = OpenFeature::SDK::Provider::NoOpProvider.new
 
-        OpenFeature::SDK.provider = provider
+        OpenFeature::SDK.set_provider(provider)
 
         expect(OpenFeature::SDK.provider).to be(provider)
-      end
-    end
-
-    context "Requirement 1.1.2.2" do
-      specify "the provider mutator must invoke an initialize function on the provider" do
-        provider = TestProvider.new
-        expect(provider).to receive(:init)
-
-        OpenFeature::SDK.provider = provider
-      end
-    end
-
-    context "Requirement 1.1.2.3" do
-      specify "the provider mutator must invoke a shutdown function on previously registered provider" do
-        previous_provider = TestProvider.new
-        new_provider = TestProvider.new
-
-        expect(previous_provider).to receive(:shutdown)
-        expect(new_provider).not_to receive(:shutdown)
-
-        OpenFeature::SDK.provider = previous_provider
-        OpenFeature::SDK.provider = new_provider
       end
     end
   end

--- a/spec/specification/flag_evaluation_api_spec.rb
+++ b/spec/specification/flag_evaluation_api_spec.rb
@@ -48,22 +48,22 @@ RSpec.describe "Flag Evaluation API" do
         first_provider = TestProvider.new
         second_provider = TestProvider.new
 
-        OpenFeature::SDK.set_provider(first_provider, name: "first")
-        OpenFeature::SDK.set_provider(second_provider, name: "second")
+        OpenFeature::SDK.set_provider(first_provider, domain: "first")
+        OpenFeature::SDK.set_provider(second_provider, domain: "second")
 
-        expect(OpenFeature::SDK.provider(name: "first")).to be(first_provider)
-        expect(OpenFeature::SDK.provider(name: "second")).to be(second_provider)
+        expect(OpenFeature::SDK.provider(domain: "first")).to be(first_provider)
+        expect(OpenFeature::SDK.provider(domain: "second")).to be(second_provider)
       end
 
       specify "if client name is already bound, it is overwritten" do
         previous_provider = TestProvider.new
         new_provider = TestProvider.new
 
-        OpenFeature::SDK.set_provider(previous_provider, name: "testing")
-        expect(OpenFeature::SDK.provider(name: "testing")).to be(previous_provider)
+        OpenFeature::SDK.set_provider(previous_provider, domain: "testing")
+        expect(OpenFeature::SDK.provider(domain: "testing")).to be(previous_provider)
 
-        OpenFeature::SDK.set_provider(new_provider, name: "testing")
-        expect(OpenFeature::SDK.provider(name: "testing")).to be(new_provider)
+        OpenFeature::SDK.set_provider(new_provider, domain: "testing")
+        expect(OpenFeature::SDK.provider(domain: "testing")).to be(new_provider)
       end
     end
   end

--- a/spec/specification/flag_evaluation_api_spec.rb
+++ b/spec/specification/flag_evaluation_api_spec.rb
@@ -20,5 +20,14 @@ RSpec.describe "Flag Evaluation API" do
         expect(OpenFeature::SDK.provider).to be(provider)
       end
     end
+
+    context "Requirement 1.1.2.2" do
+      specify "the provider mutator must invoke an initialize function on the provider" do
+        provider = double
+        expect(provider).to receive(:init)
+
+        OpenFeature::SDK.set_provider(provider)
+      end
+    end
   end
 end

--- a/spec/specification/flag_evaluation_api_spec.rb
+++ b/spec/specification/flag_evaluation_api_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Flag Evaluation API" do
       specify "the API must define a provider mutator" do
         provider = OpenFeature::SDK::Provider::NoOpProvider.new
 
-        OpenFeature::SDK.set_provider(provider)
+        OpenFeature::SDK.provider = provider
 
         expect(OpenFeature::SDK.provider).to be(provider)
       end
@@ -26,7 +26,7 @@ RSpec.describe "Flag Evaluation API" do
         provider = TestProvider.new
         expect(provider).to receive(:init)
 
-        OpenFeature::SDK.set_provider(provider)
+        OpenFeature::SDK.provider = provider
       end
     end
 
@@ -38,8 +38,8 @@ RSpec.describe "Flag Evaluation API" do
         expect(previous_provider).to receive(:shutdown)
         expect(new_provider).not_to receive(:shutdown)
 
-        OpenFeature::SDK.set_provider(previous_provider)
-        OpenFeature::SDK.set_provider(new_provider)
+        OpenFeature::SDK.provider = previous_provider
+        OpenFeature::SDK.provider = new_provider
       end
     end
   end


### PR DESCRIPTION
## This PR

Only the last four commits will be merged in with this PR. The others are waiting on #77 and #78.

- *Breaking*: Renamed `API.provider=(provider)` to `API.set_provider(provider, domain: nil)` to better adhere to the specification. I decided to move away from the `attr_writer` naming convention as the `domain` parameter would be surprising. I would love others' thoughts on this.
- Provider instances are now stored inside a provider hash in the config instance, with the default provider using `nil` as the key. The other option I tried here was to store `@default_provider` in addition to the hash, but this approach was simpler to the slight detriment of readability.
- Refactored `API.provider` to receive `domain` as a keyword argument. If no domain is provided, it will return the default provider. This is backward compatible.
- Implemented Requirement 1.1.3 from spec version 0.7.0.

### Follow-up Tasks
In subsequent PRs, I'll continue on the flag evaluation specifications.

### How to test
Open a console and play around with the `set_provider` method on the API. If no name is provided, the default provider will be replaced. If a name is provided, the provider will be registered using that name. If the same name is provided, the provider will be overridden.

