### PR TITLE
feat: Updates to `Provider` module in preparation for `InMemoryProvider`

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "openfeature/sdk"
+require "open_feature/sdk"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/open_feature/sdk/api.rb
+++ b/lib/open_feature/sdk/api.rb
@@ -4,6 +4,7 @@ require "forwardable"
 require "singleton"
 
 require_relative "configuration"
+require_relative "evaluation_details"
 require_relative "client"
 require_relative "metadata"
 require_relative "provider"

--- a/lib/open_feature/sdk/api.rb
+++ b/lib/open_feature/sdk/api.rb
@@ -30,9 +30,7 @@ module OpenFeature
       include Singleton
       extend Forwardable
 
-      def_delegator :configuration, :provider
-      def_delegator :configuration, :hooks
-      def_delegator :configuration, :context
+      def_delegators :configuration, :provider, :hooks, :context
 
       def configuration
         @configuration ||= Configuration.new

--- a/lib/open_feature/sdk/api.rb
+++ b/lib/open_feature/sdk/api.rb
@@ -6,7 +6,7 @@ require "singleton"
 require_relative "configuration"
 require_relative "client"
 require_relative "metadata"
-require_relative "provider/no_op_provider"
+require_relative "provider"
 
 module OpenFeature
   module SDK

--- a/lib/open_feature/sdk/api.rb
+++ b/lib/open_feature/sdk/api.rb
@@ -29,9 +29,9 @@ module OpenFeature
       include Singleton
       extend Forwardable
 
-      def_delegator :@configuration, :provider
-      def_delegator :@configuration, :hooks
-      def_delegator :@configuration, :context
+      def_delegator :configuration, :provider
+      def_delegator :configuration, :hooks
+      def_delegator :configuration, :context
 
       def configuration
         @configuration ||= Configuration.new

--- a/lib/open_feature/sdk/client.rb
+++ b/lib/open_feature/sdk/client.rb
@@ -26,8 +26,9 @@ module OpenFeature
             #   result = @provider.fetch_boolean_value(flag_key: flag_key, default_value: default_value, evaluation_context: evaluation_context)
             # end
             def fetch_#{result_type}_#{suffix}(flag_key:, default_value:, evaluation_context: nil)
-              result = @provider.fetch_#{result_type}_value(flag_key: flag_key, default_value: default_value, evaluation_context: evaluation_context)
-              #{"result.value" if suffix == :value}
+              resolution_details = @provider.fetch_#{result_type}_value(flag_key:, default_value:, evaluation_context:)
+              evaluation_details = EvaluationDetails.new(flag_key:, resolution_details:)
+              #{"evaluation_details.value" if suffix == :value}
             end
           RUBY
         end

--- a/lib/open_feature/sdk/evaluation_details.rb
+++ b/lib/open_feature/sdk/evaluation_details.rb
@@ -1,0 +1,9 @@
+module OpenFeature
+  module SDK
+    EvaluationDetails = Struct.new(:flag_key, :resolution_details) do
+      extend Forwardable
+
+      def_delegators :resolution_details, :value, :reason, :variant, :error_code, :error_message, :flag_metadata
+    end
+  end
+end

--- a/lib/open_feature/sdk/evaluation_details.rb
+++ b/lib/open_feature/sdk/evaluation_details.rb
@@ -1,6 +1,6 @@
 module OpenFeature
   module SDK
-    EvaluationDetails = Struct.new(:flag_key, :resolution_details) do
+    EvaluationDetails = Struct.new(:flag_key, :resolution_details, keyword_init: true) do
       extend Forwardable
 
       def_delegators :resolution_details, :value, :reason, :variant, :error_code, :error_message, :flag_metadata

--- a/lib/open_feature/sdk/provider.rb
+++ b/lib/open_feature/sdk/provider.rb
@@ -1,0 +1,9 @@
+require_relative "provider/resolution_details"
+require_relative "provider/no_op_provider"
+
+module OpenFeature
+  module SDK
+    module Provider
+    end
+  end
+end

--- a/lib/open_feature/sdk/provider.rb
+++ b/lib/open_feature/sdk/provider.rb
@@ -1,3 +1,5 @@
+require_relative "provider/error_code"
+require_relative "provider/reason"
 require_relative "provider/resolution_details"
 require_relative "provider/no_op_provider"
 

--- a/lib/open_feature/sdk/provider/error_code.rb
+++ b/lib/open_feature/sdk/provider/error_code.rb
@@ -1,0 +1,15 @@
+module OpenFeature
+  module SDK
+    module Provider
+      module ErrorCode
+        PROVIDER_NOT_READY = "Provider Not Ready"
+        FLAG_NOT_FOUND = "Flag Not Found"
+        PARSE_ERROR = "Parse Error"
+        TYPE_MISMATCH = "Type Mismatch"
+        TARGETING_KEY_MISSING = "Targeting Key Missing"
+        INVALID_CONTEXT = "Invalid Context"
+        GENERAL = "General"
+      end
+    end
+  end
+end

--- a/lib/open_feature/sdk/provider/no_op_provider.rb
+++ b/lib/open_feature/sdk/provider/no_op_provider.rb
@@ -30,8 +30,6 @@ module OpenFeature
 
         attr_reader :metadata
 
-        ResolutionDetails = Struct.new(:value, :reason, :variant, :error_code, :error_message)
-
         def initialize
           @metadata = Metadata.new(name: NAME).freeze
         end

--- a/lib/open_feature/sdk/provider/reason.rb
+++ b/lib/open_feature/sdk/provider/reason.rb
@@ -1,0 +1,17 @@
+module OpenFeature
+  module SDK
+    module Provider
+      module Reason
+        STATIC = "Static"
+        DEFAULT = "Default"
+        TARGETING_MATCH = "Targeting Match"
+        SPLIT = "Split"
+        CACHED = "Cached"
+        DISABLED = "Disabled"
+        UNKNOWN = "Unknown"
+        STALE = "Stale"
+        ERROR = "Error"
+      end
+    end
+  end
+end

--- a/lib/open_feature/sdk/provider/resolution_details.rb
+++ b/lib/open_feature/sdk/provider/resolution_details.rb
@@ -1,0 +1,7 @@
+module OpenFeature
+  module SDK
+    module Provider
+      ResolutionDetails = Struct.new(:value, :reason, :variant, :error_code, :error_message, :flag_metadata)
+    end
+  end
+end

--- a/lib/open_feature/sdk/provider/resolution_details.rb
+++ b/lib/open_feature/sdk/provider/resolution_details.rb
@@ -1,7 +1,7 @@
 module OpenFeature
   module SDK
     module Provider
-      ResolutionDetails = Struct.new(:value, :reason, :variant, :error_code, :error_message, :flag_metadata)
+      ResolutionDetails = Struct.new(:value, :reason, :variant, :error_code, :error_message, :flag_metadata, keyword_init: true)
     end
   end
 end

--- a/spec/open_feature/sdk/client_spec.rb
+++ b/spec/open_feature/sdk/client_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe OpenFeature::SDK::Client do
           end
 
           it do
-            expect(client.fetch_boolean_details(flag_key: flag_key, default_value: false)).is_a?(OpenFeature::SDK::Provider::NoOpProvider::ResolutionDetails)
+            expect(client.fetch_boolean_details(flag_key: flag_key, default_value: false)).is_a?(OpenFeature::SDK::Provider::ResolutionDetails)
           end
         end
 
@@ -136,8 +136,8 @@ RSpec.describe OpenFeature::SDK::Client do
           end
 
           it do
-            expect(client.fetch_number_details(flag_key: flag_key, default_value: 1.2)).is_a?(OpenFeature::SDK::Provider::NoOpProvider::ResolutionDetails)
-            expect(client.fetch_number_details(flag_key: flag_key, default_value: 1)).is_a?(OpenFeature::SDK::Provider::NoOpProvider::ResolutionDetails)
+            expect(client.fetch_number_details(flag_key: flag_key, default_value: 1.2)).is_a?(OpenFeature::SDK::Provider::ResolutionDetails)
+            expect(client.fetch_number_details(flag_key: flag_key, default_value: 1)).is_a?(OpenFeature::SDK::Provider::ResolutionDetails)
           end
         end
 
@@ -166,7 +166,7 @@ RSpec.describe OpenFeature::SDK::Client do
           end
 
           it do
-            expect(client.fetch_string_details(flag_key: flag_key, default_value: "some-string")).is_a?(OpenFeature::SDK::Provider::NoOpProvider::ResolutionDetails)
+            expect(client.fetch_string_details(flag_key: flag_key, default_value: "some-string")).is_a?(OpenFeature::SDK::Provider::ResolutionDetails)
           end
         end
 
@@ -195,7 +195,7 @@ RSpec.describe OpenFeature::SDK::Client do
 
           it do
             expect(client.fetch_object_details(flag_key: flag_key,
-              default_value: {name: "some-name"})).is_a?(OpenFeature::SDK::Provider::NoOpProvider::ResolutionDetails)
+              default_value: {name: "some-name"})).is_a?(OpenFeature::SDK::Provider::ResolutionDetails)
           end
         end
 


### PR DESCRIPTION
## This PR
- Fixes two bugs I encountered during local development (`bin/console` not loading and a memorization issue with `Configuration`
- Adds constants for `Reason` and `ErrorCode` enumerations
- Refactored `ResolutionDetails` up a module layer, and updated the client to return an `EvaluationDetails` struct, matching a callout from a spec:

> The resolution details structure is not exposed to the Application Author. It defines the data which Provider Authors must return when resolving the value of flags.

(Note at the bottom of [this section](https://openfeature.dev/specification/types#resolution-details))

### Follow-up Tasks
- Following this PR, I will PR the `InMemoryProvider` that I've been working on to satisfy a utility in [Appendix A](https://openfeature.dev/specification/appendix-a#in-memory-provider).