### PR TITLE
ci: downgrade release please, set pre-major version bump

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,12 +10,13 @@ jobs:
 
     # Release-please creates a PR that tracks all changes
     steps:
-      - uses: google-github-actions/release-please-action@cc61a07e2da466bebbc19b3a7dd01d6aecb20d1e # v4
+      - uses: google-github-actions/release-please-action@v3
         id: release
         with:
           release-type: ruby
           package-name: openfeature-sdk
           bump-minor-pre-major: true
+          bump-patch-for-minor-pre-major: true
           version-file: "lib/open_feature/sdk/version.rb"
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## This PR

- downgrades release please due to a bug in v4
- sub-version 1 release bump only bump minor and patch version

### Notes

This should prevent a [premature 1.0 release](https://github.com/open-feature/ruby-sdk/pull/92).

