### PR TITLE
feat: Add evaluation context based on requirement 3.1.1

### DIFF
--- a/lib/open_feature/sdk/api.rb
+++ b/lib/open_feature/sdk/api.rb
@@ -4,6 +4,7 @@ require "forwardable"
 require "singleton"
 
 require_relative "configuration"
+require_relative "evaluation_context"
 require_relative "evaluation_details"
 require_relative "client"
 require_relative "metadata"

--- a/lib/open_feature/sdk/evaluation_context.rb
+++ b/lib/open_feature/sdk/evaluation_context.rb
@@ -1,10 +1,16 @@
 module OpenFeature
   module SDK
     class EvaluationContext
-      attr_reader :targeting_key
+      TARGETING_KEY = "targeting_key"
 
-      def initialize(targeting_key: nil)
-        @targeting_key = targeting_key
+      attr_reader :fields
+
+      def initialize(targeting_key: nil, **fields)
+        @fields = {TARGETING_KEY => targeting_key}.merge(fields)
+      end
+
+      def targeting_key
+        fields[TARGETING_KEY]
       end
     end
   end

--- a/lib/open_feature/sdk/evaluation_context.rb
+++ b/lib/open_feature/sdk/evaluation_context.rb
@@ -12,6 +12,10 @@ module OpenFeature
       def targeting_key
         fields[TARGETING_KEY]
       end
+
+      def field(key)
+        fields[key]
+      end
     end
   end
 end

--- a/lib/open_feature/sdk/evaluation_context.rb
+++ b/lib/open_feature/sdk/evaluation_context.rb
@@ -1,0 +1,11 @@
+module OpenFeature
+  module SDK
+    class EvaluationContext
+      attr_reader :targeting_key
+
+      def initialize(targeting_key: nil)
+        @targeting_key = targeting_key
+      end
+    end
+  end
+end

--- a/spec/specification/evaluation_context_spec.rb
+++ b/spec/specification/evaluation_context_spec.rb
@@ -21,5 +21,23 @@ RSpec.describe "Evaluation Context" do
         expect(context_with_custom_fields.fields).to eq({"favorite_fruit" => "banana", "favorite_music" => "maryland beach ska rock", "targeting_key" => nil})
       end
     end
+
+    context "Requirement 3.1.3" do
+      specify "The evaluation context MUST support fetching the custom fields by key" do
+        expect(context_with_custom_fields.field("favorite_music")).to eq("maryland beach ska rock")
+      end
+
+      specify "and also fetching all key value pairs." do
+        expect(context_with_custom_fields.fields).to eq({"favorite_fruit" => "banana", "favorite_music" => "maryland beach ska rock", "targeting_key" => nil})
+      end
+    end
+
+    context "Requirement 3.1.4" do
+      specify "The evaluation context fields MUST have an unique key." do
+        context = OpenFeature::SDK::EvaluationContext.new("favorite_fruit" => "banana", "favorite_fruit" => "apple") # standard:disable Lint/DuplicateHashKey
+
+        expect(context.fields).to eq({"favorite_fruit" => "apple", "targeting_key" => nil})
+      end
+    end
   end
 end

--- a/spec/specification/evaluation_context_spec.rb
+++ b/spec/specification/evaluation_context_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Evaluation Context" do
+  context "3.1 Fields" do
+    context "Requirement 3.1.1" do
+      specify "The evaluation context structure MUST define an optional targeting key field of type string, identifying the subject of the flag evaluation." do
+        context_with_targeting = OpenFeature::SDK::EvaluationContext.new(targeting_key: "test target")
+        context_without_targeting = OpenFeature::SDK::EvaluationContext.new
+
+        expect(context_with_targeting.targeting_key).to eq("test target")
+        expect(context_without_targeting.targeting_key).to be_nil
+      end
+    end
+  end
+end

--- a/spec/specification/evaluation_context_spec.rb
+++ b/spec/specification/evaluation_context_spec.rb
@@ -4,6 +4,8 @@ require "spec_helper"
 
 RSpec.describe "Evaluation Context" do
   context "3.1 Fields" do
+    let(:context_with_custom_fields) { OpenFeature::SDK::EvaluationContext.new("favorite_fruit" => "banana", "favorite_music" => "maryland beach ska rock") }
+
     context "Requirement 3.1.1" do
       specify "The evaluation context structure MUST define an optional targeting key field of type string, identifying the subject of the flag evaluation." do
         context_with_targeting = OpenFeature::SDK::EvaluationContext.new(targeting_key: "test target")
@@ -11,6 +13,12 @@ RSpec.describe "Evaluation Context" do
 
         expect(context_with_targeting.targeting_key).to eq("test target")
         expect(context_without_targeting.targeting_key).to be_nil
+      end
+    end
+
+    context "Requirement 3.1.2" do
+      specify "The evaluation context MUST support the inclusion of custom fields, having keys of type string, and values of type boolean | string | number | datetime | structure." do
+        expect(context_with_custom_fields.fields).to eq({"favorite_fruit" => "banana", "favorite_music" => "maryland beach ska rock", "targeting_key" => nil})
       end
     end
   end


### PR DESCRIPTION
## This PR

- adds a basic `EvaluationContext` which fulfills requirement 3.1. Note that this isn't used anywhere yet and I will continue to build it out by adding new spec requirements.

### Follow-up Tasks
Will continue implementing other parts of EC and use it in clients