### PR TITLE
feat: add integer and float specific resolver methods

### DIFF
--- a/lib/open_feature/sdk/client.rb
+++ b/lib/open_feature/sdk/client.rb
@@ -5,7 +5,7 @@ module OpenFeature
     # TODO: Write documentation
     #
     class Client
-      RESULT_TYPE = %i[boolean string number object].freeze
+      RESULT_TYPE = %i[boolean string number integer float object].freeze
       SUFFIXES = %i[value details].freeze
 
       attr_reader :metadata, :evaluation_context

--- a/lib/open_feature/sdk/provider/in_memory_provider.rb
+++ b/lib/open_feature/sdk/provider/in_memory_provider.rb
@@ -34,7 +34,15 @@ module OpenFeature
         end
 
         def fetch_number_value(flag_key:, default_value:, evaluation_context: nil)
-          fetch_value(allowed_classes: [Integer, Float], flag_key:, default_value:, evaluation_context:)
+          fetch_value(allowed_classes: [Numeric], flag_key:, default_value:, evaluation_context:)
+        end
+
+        def fetch_integer_value(flag_key:, default_value:, evaluation_context: nil)
+          fetch_value(allowed_classes: [Integer], flag_key:, default_value:, evaluation_context:)
+        end
+
+        def fetch_float_value(flag_key:, default_value:, evaluation_context: nil)
+          fetch_value(allowed_classes: [Float], flag_key:, default_value:, evaluation_context:)
         end
 
         def fetch_object_value(flag_key:, default_value:, evaluation_context: nil)
@@ -52,7 +60,7 @@ module OpenFeature
             return ResolutionDetails.new(value: default_value, error_code: ErrorCode::FLAG_NOT_FOUND, reason: Reason::ERROR)
           end
 
-          if allowed_classes.include?(value.class)
+          if allowed_classes.any? { |klass| value.is_a?(klass) }
             ResolutionDetails.new(value:, reason: Reason::STATIC)
           else
             ResolutionDetails.new(value: default_value, error_code: ErrorCode::TYPE_MISMATCH, reason: Reason::ERROR)

--- a/lib/open_feature/sdk/provider/no_op_provider.rb
+++ b/lib/open_feature/sdk/provider/no_op_provider.rb
@@ -44,6 +44,14 @@ module OpenFeature
           no_op(default_value)
         end
 
+        def fetch_integer_value(flag_key:, default_value:, evaluation_context: nil)
+          no_op(default_value)
+        end
+
+        def fetch_float_value(flag_key:, default_value:, evaluation_context: nil)
+          no_op(default_value)
+        end
+
         def fetch_object_value(flag_key:, default_value:, evaluation_context: nil)
           no_op(default_value)
         end

--- a/spec/open_feature/sdk/client_spec.rb
+++ b/spec/open_feature/sdk/client_spec.rb
@@ -64,13 +64,21 @@ RSpec.describe OpenFeature::SDK::Client do
             expect(client).to respond_to(:fetch_number_value)
           end
 
-          context "Condition 1.3.2 - The implementation language differentiates between floating-point numbers and integers." do
+          it do
+            expect(client.fetch_number_value(flag_key: flag_key, default_value: 4)).is_a?(Integer)
+          end
+
+          it do
+            expect(client.fetch_number_value(flag_key: flag_key, default_value: 95.5)).is_a?(Float)
+          end
+
+          context "Condition 1.3.3 - The implementation language differentiates between floating-point numbers and integers." do
             it do
-              expect(client.fetch_number_value(flag_key: flag_key, default_value: 4)).is_a?(Integer)
+              expect(client.fetch_integer_value(flag_key: flag_key, default_value: 4)).is_a?(Integer)
             end
 
             it do
-              expect(client.fetch_number_value(flag_key: flag_key, default_value: 95.5)).is_a?(Float)
+              expect(client.fetch_float_value(flag_key: flag_key, default_value: 95.5)).is_a?(Float)
             end
           end
         end

--- a/spec/open_feature/sdk/provider/in_memory_provider_spec.rb
+++ b/spec/open_feature/sdk/provider/in_memory_provider_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe OpenFeature::SDK::Provider::InMemoryProvider do
       {
         "bool" => true,
         "str" => "testing",
-        "num" => 1,
+        "int" => 1,
+        "float" => 1.0,
         "struct" => {"more" => "config"}
       }
     )
@@ -103,8 +104,47 @@ RSpec.describe OpenFeature::SDK::Provider::InMemoryProvider do
   describe "#fetch_number_value" do
     context "when flag is found" do
       context "when type matches" do
+        it "returns int as static" do
+          fetched = provider.fetch_number_value(flag_key: "int", default_value: 0)
+
+          expect(fetched.value).to eq(1)
+          expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::STATIC)
+        end
+        it "returns float as static" do
+          fetched = provider.fetch_number_value(flag_key: "float", default_value: 0.0)
+
+          expect(fetched.value).to eq(1.0)
+          expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::STATIC)
+        end
+      end
+
+      context "when type does not match" do
+        it "returns default as type mismatch" do
+          fetched = provider.fetch_number_value(flag_key: "str", default_value: 0)
+
+          expect(fetched.value).to eq(0)
+          expect(fetched.error_code).to eq(OpenFeature::SDK::Provider::ErrorCode::TYPE_MISMATCH)
+          expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::ERROR)
+        end
+      end
+    end
+
+    context "when flag is not found" do
+      it "returns default as flag not found" do
+        fetched = provider.fetch_number_value(flag_key: "not here", default_value: 0)
+
+        expect(fetched.value).to eq(0)
+        expect(fetched.error_code).to eq(OpenFeature::SDK::Provider::ErrorCode::FLAG_NOT_FOUND)
+        expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::ERROR)
+      end
+    end
+  end
+
+  describe "#fetch_integer_value" do
+    context "when flag is found" do
+      context "when type matches" do
         it "returns value as static" do
-          fetched = provider.fetch_number_value(flag_key: "num", default_value: 0)
+          fetched = provider.fetch_integer_value(flag_key: "int", default_value: 0)
 
           expect(fetched.value).to eq(1)
           expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::STATIC)
@@ -113,7 +153,40 @@ RSpec.describe OpenFeature::SDK::Provider::InMemoryProvider do
 
       context "when type does not match" do
         it "returns default as type mismatch" do
-          fetched = provider.fetch_number_value(flag_key: "str", default_value: 0)
+          fetched = provider.fetch_integer_value(flag_key: "float", default_value: 0)
+
+          expect(fetched.value).to eq(0)
+          expect(fetched.error_code).to eq(OpenFeature::SDK::Provider::ErrorCode::TYPE_MISMATCH)
+          expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::ERROR)
+        end
+      end
+    end
+
+    context "when flag is not found" do
+      it "returns default as flag not found" do
+        fetched = provider.fetch_number_value(flag_key: "not here", default_value: 0)
+
+        expect(fetched.value).to eq(0)
+        expect(fetched.error_code).to eq(OpenFeature::SDK::Provider::ErrorCode::FLAG_NOT_FOUND)
+        expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::ERROR)
+      end
+    end
+  end
+
+  describe "#fetch_integer_value" do
+    context "when flag is found" do
+      context "when type matches" do
+        it "returns value as static" do
+          fetched = provider.fetch_float_value(flag_key: "float", default_value: 0.0)
+
+          expect(fetched.value).to eq(1.0)
+          expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::STATIC)
+        end
+      end
+
+      context "when type does not match" do
+        it "returns default as type mismatch" do
+          fetched = provider.fetch_float_value(flag_key: "int", default_value: 0.0)
 
           expect(fetched.value).to eq(0)
           expect(fetched.error_code).to eq(OpenFeature::SDK::Provider::ErrorCode::TYPE_MISMATCH)
@@ -146,7 +219,7 @@ RSpec.describe OpenFeature::SDK::Provider::InMemoryProvider do
 
       context "when type does not match" do
         it "returns default as type mismatch" do
-          fetched = provider.fetch_object_value(flag_key: "num", default_value: {})
+          fetched = provider.fetch_object_value(flag_key: "int", default_value: {})
 
           expect(fetched.value).to eq({})
           expect(fetched.error_code).to eq(OpenFeature::SDK::Provider::ErrorCode::TYPE_MISMATCH)


### PR DESCRIPTION
## This PR

- adds support for [Conditional Requirement 1.3.3.1 ](https://openfeature.dev/specification/sections/flag-evaluation/#condition-133) to the client, as well as the included providers
- modifies the `InMemoryProvider` to work  slightly better with subclasses

### Related Issues

Fixes #121 

### Notes
It's somewhat weird that the client's tests use an actual `NoopProvider` instead of a mock. That kind of couples these changes more than i'd like to. But that's just how it is for now :) 
I'm also wondering, if we wouldn't actually need a slightly more elaborated solution where the client falls back to the `fetch_number` method on the rovider, if it doesn't have a `fetch_integer`/`fetch_float`. The reason is, that currently the client blindly delegates these calls, and there might be providers out in the wild. 