### PR TITLE
feat!: Use strings from spec for error and reason enums

### DIFF
--- a/lib/open_feature/sdk/provider/error_code.rb
+++ b/lib/open_feature/sdk/provider/error_code.rb
@@ -2,13 +2,14 @@ module OpenFeature
   module SDK
     module Provider
       module ErrorCode
-        PROVIDER_NOT_READY = "Provider Not Ready"
-        FLAG_NOT_FOUND = "Flag Not Found"
-        PARSE_ERROR = "Parse Error"
-        TYPE_MISMATCH = "Type Mismatch"
-        TARGETING_KEY_MISSING = "Targeting Key Missing"
-        INVALID_CONTEXT = "Invalid Context"
-        GENERAL = "General"
+        PROVIDER_NOT_READY = "PROVIDER_NOT_READY"
+        FLAG_NOT_FOUND = "FLAG_NOT_FOUND"
+        PARSE_ERROR = "PARSE_ERROR"
+        TYPE_MISMATCH = "TYPE_MISMATCH"
+        TARGETING_KEY_MISSING = "TARGETING_KEY_MISSING"
+        INVALID_CONTEXT = "INVALID_CONTEXT"
+        PROVIDER_FATAL = "PROVIDER_FATAL"
+        GENERAL = "GENERAL"
       end
     end
   end

--- a/lib/open_feature/sdk/provider/reason.rb
+++ b/lib/open_feature/sdk/provider/reason.rb
@@ -2,15 +2,15 @@ module OpenFeature
   module SDK
     module Provider
       module Reason
-        STATIC = "Static"
-        DEFAULT = "Default"
-        TARGETING_MATCH = "Targeting Match"
-        SPLIT = "Split"
-        CACHED = "Cached"
-        DISABLED = "Disabled"
-        UNKNOWN = "Unknown"
-        STALE = "Stale"
-        ERROR = "Error"
+        STATIC = "STATIC"
+        DEFAULT = "DEFAULT"
+        TARGETING_MATCH = "TARGETING_MATCH"
+        SPLIT = "SPLIT"
+        CACHED = "CACHED"
+        DISABLED = "DISABLED"
+        UNKNOWN = "UNKNOWN"
+        STALE = "STALE"
+        ERROR = "ERROR"
       end
     end
   end


### PR DESCRIPTION
Fixes #123

Upper cases error and reason enum values and adds missing 'PROVIDER_FATAL' error
