### PR TITLE
docs: Update README to match OpenFeature template

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -1,0 +1,98 @@
+# Contributing to the OpenFeature project
+
+## Development
+
+You can contribute to this project from a Windows, macOS or Linux machine.
+
+On all platforms, the minimum requirements are:
+
+* Git client and command line tools.
+* Ruby 3.0 or higher
+
+## Pull Request
+
+All contributions to the OpenFeature project are welcome via GitHub pull requests.
+
+To create a new PR, you will need to first fork the GitHub repository and clone upstream.
+
+```bash
+git clone https://github.com/open-feature/ruby-sdk.git openfeature-ruby-sdk
+```
+
+Navigate to the repository folder
+```bash
+cd openfeature-ruby-sdk
+```
+
+Add your fork as an origin
+```bash
+git remote add fork https://github.com/YOUR_GITHUB_USERNAME/ruby-sdk.git
+```
+
+To start working on a new feature or bugfix, create a new branch and start working on it.
+
+```bash
+git checkout -b feat/NAME_OF_FEATURE
+# Make your changes
+git commit
+git push fork feat/NAME_OF_FEATURE
+```
+
+Open a pull request against the main ruby-sdk repository.
+
+### Running checks locally
+
+#### Unit tests
+
+To run unit tests and other checks:
+
+```bash
+bundle exec rake
+```
+
+### How to Receive Comments
+
+* If the PR is not ready for review, please mark it as
+  [`draft`](https://github.blog/2019-02-14-introducing-draft-pull-requests/).
+* Make sure all required CI checks are clear.
+* Submit small, focused PRs addressing a single concern/issue.
+* Make sure the PR title reflects the contribution.
+* Write a summary that helps understand the change.
+* Include usage examples in the summary, where applicable.
+
+### How to Get PRs Merged
+
+A PR is considered to be **ready to merge** when:
+
+* Major feedbacks are resolved.
+* It has been open for review for at least one working day. This gives people
+  reasonable time to review.
+* Trivial change (typo, cosmetic, doc, etc.) doesn't have to wait for one day.
+* Urgent fix can take exception as long as it has been actively communicated.
+
+Any Maintainer can merge the PR once it is **ready to merge**. Note, that some
+PRs may not be merged immediately if the repo is in the process of a release and
+the maintainers decided to defer the PR to the next release train.
+
+If a PR has been stuck (e.g. there are lots of debates and people couldn't agree
+on each other), the owner should try to get people aligned by:
+
+* Consolidating the perspectives and putting a summary in the PR. It is
+  recommended to add a link into the PR description, which points to a comment
+  with a summary in the PR conversation.
+* Tagging subdomain experts (by looking at the change history) in the PR asking
+  for suggestion.
+* Reaching out to more people on the [CNCF OpenFeature Slack channel](https://cloud-native.slack.com/archives/C0344AANLA1).
+* Stepping back to see if it makes sense to narrow down the scope of the PR or
+  split it up.
+* If none of the above worked and the PR has been stuck for more than 2 weeks,
+  the owner should bring it to the OpenFeatures [meeting](README.md#contributing).
+
+## Automated Changelog
+
+Each time a release is published the changelogs will be generated automatically using `release-please`.
+
+## Design Choices
+
+As with other OpenFeature SDKs, ruby-sdk follows the
+[openfeature-specification](https://github.com/open-feature/spec).

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@
 
   <!-- x-release-please-end -->
   <br/>
-  <a href="https://bestpractices.coreinfrastructure.org/projects/6601">
-    <img alt="CII Best Practices" src="https://bestpractices.coreinfrastructure.org/projects/6601/badge" />
+  <a href="https://bestpractices.coreinfrastructure.org/projects/9337">
+    <img alt="CII Best Practices" src="https://bestpractices.coreinfrastructure.org/projects/9337/badge" />
   </a>
 </p>
 <!-- x-hide-in-docs-start -->
@@ -110,7 +110,7 @@ object = client.fetch_object_value(flag_key: 'object_value', default_value: JSON
 ### Providers
 
 [Providers](https://openfeature.dev/docs/reference/concepts/provider) are an abstraction between a flag management system and the OpenFeature SDK.
-Look [here](https://openfeature.dev/ecosystem?instant_search%5BrefinementList%5D%5Btype%5D%5B0%5D=Provider&instant_search%5BrefinementList%5D%5Btechnology%5D%5B0%5D=ruby) for a complete list of available providers.
+Look [here](https://openfeature.dev/ecosystem?instant_search%5BrefinementList%5D%5Btype%5D%5B0%5D=Provider&instant_search%5BrefinementList%5D%5Btechnology%5D%5B0%5D=Ruby) for a complete list of available providers.
 If the provider you're looking for hasn't been created yet, see the [develop a provider](#develop-a-provider) section to learn how to build it yourself.
 
 Once you've added a provider as a dependency, it can be registered with OpenFeature like this:
@@ -161,7 +161,7 @@ bool_value = client.fetch_boolean_value(
 Coming Soon!
 
 <!-- [Hooks](https://openfeature.dev/docs/reference/concepts/hooks) allow for custom logic to be added at well-defined points of the flag evaluation life-cycle.
-Look [here](https://openfeature.dev/ecosystem/?instant_search%5BrefinementList%5D%5Btype%5D%5B0%5D=Hook&instant_search%5BrefinementList%5D%5Btechnology%5D%5B0%5D=ruby) for a complete list of available hooks.
+Look [here](https://openfeature.dev/ecosystem/?instant_search%5BrefinementList%5D%5Btype%5D%5B0%5D=Hook&instant_search%5BrefinementList%5D%5Btechnology%5D%5B0%5D=Ruby) for a complete list of available hooks.
 If the hook you're looking for hasn't been created yet, see the [develop a hook](#develop-a-hook) section to learn how to build it yourself.
 
 Once you've added a hook as a dependency, it can be registered at the global, client, or flag invocation level. -->

--- a/README.md
+++ b/README.md
@@ -1,24 +1,48 @@
-# OpenFeature SDK for Ruby
+<!-- markdownlint-disable MD033 -->
+<!-- x-hide-in-docs-start -->
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/open-feature/community/0e23508c163a6a1ac8c0ced3e4bd78faafe627c7/assets/logo/horizontal/white/openfeature-horizontal-white.svg" />
+    <img align="center" alt="OpenFeature Logo" src="https://raw.githubusercontent.com/open-feature/community/0e23508c163a6a1ac8c0ced3e4bd78faafe627c7/assets/logo/horizontal/black/openfeature-horizontal-black.svg" />
+  </picture>
+</p>
 
-[![a](https://img.shields.io/badge/slack-%40cncf%2Fopenfeature-brightgreen?style=flat&logo=slack)](https://cloud-native.slack.com/archives/C0344AANLA1)
-[![v0.5.1](https://img.shields.io/static/v1?label=Specification&message=v0.5.1&color=yellow)](https://github.com/open-feature/spec/tree/v0.5.1)
-![Ruby](https://img.shields.io/badge/ruby-%23CC342D.svg?style=for-the-badge&logo=ruby&logoColor=white)
-![Build](https://github.com/open-feature/openfeature-ruby/actions/workflows/main.yml/badge.svg?branch=main)
-![Gem version](https://img.shields.io/gem/v/openfeature-sdk)
+<h2 align="center">OpenFeature Ruby SDK</h2>
 
-This is the Ruby implementation of [OpenFeature](https://openfeature.dev), a vendor-agnostic abstraction library for evaluating feature flags.
+<!-- x-hide-in-docs-end -->
+<!-- The 'github-badges' class is used in the docs -->
+<p align="center" class="github-badges">
+  <a href="https://github.com/open-feature/spec/releases/tag/v0.8.0">
+    <img alt="Specification" src="https://img.shields.io/static/v1?label=specification&message=v0.8.0&color=yellow&style=for-the-badge" />
+  </a>
+  <!-- x-release-please-start-version -->
 
-We support multiple data types for flags (numbers, strings, booleans, objects) as well as hooks, which can alter the lifecycle of a flag evaluation.
+  <a href="https://github.com/open-feature/ruby-sdk/releases/tag/v0.4.0">
+    <img alt="Release" src="https://img.shields.io/static/v1?label=release&message=v0.4.0&color=blue&style=for-the-badge" />
+  </a>
 
-## Support Matrix
+  <!-- x-release-please-end -->
+  <br/>
+  <a href="https://bestpractices.coreinfrastructure.org/projects/6601">
+    <img alt="CII Best Practices" src="https://bestpractices.coreinfrastructure.org/projects/6601/badge" />
+  </a>
+</p>
+<!-- x-hide-in-docs-start -->
 
-| Ruby Version | OS                    |
+[OpenFeature](https://openfeature.dev) is an open specification that provides a vendor-agnostic, community-driven API for feature flagging that works with your favorite feature flag management tool or in-house solution.
+
+<!-- x-hide-in-docs-end -->
+## 🚀 Quick start
+
+### Requirements
+
+| Supported Ruby Version | OS                    |
 | ------------ | --------------------- |
 | Ruby 3.1.4   | Windows, MacOS, Linux |
 | Ruby 3.2.3   | Windows, MacOS, Linux |
 | Ruby 3.3.0   | Windows, MacOS, Linux |
 
-## Installation
+### Install
 
 Install the gem and add to the application's Gemfile by executing:
 
@@ -32,7 +56,7 @@ If bundler is not being used to manage dependencies, install the gem by executin
 gem install openfeature-sdk
 ```
 
-## Usage
+### Usage
 
 ```ruby
 require 'open_feature/sdk'
@@ -48,20 +72,10 @@ OpenFeature::SDK.configure do |config|
       "flag2" => 1
     }
   ))
-  # alternatively, you can bind multiple providers to different domains
-  config.set_provider(OpenFeature::SDK::Provider::NoOpProvider.new, domain: "legacy_flags")
-  # you can set a global evaluation context here
-  config.evaluation_context = OpenFeature::SDK::EvaluationContext.new("host" => "myhost.com")
 end
 
 # Create a client
 client = OpenFeature::SDK.build_client
-# Create a client for a different domain, this will use the provider assigned to that domain
-legacy_flag_client = OpenFeature::SDK.build_client(domain: "legacy_flags")
-# Evaluation context can be set on a client as well
-client_with_context = OpenFeature::SDK.build_client(
-  evaluation_context: OpenFeature::SDK::EvaluationContext.new("controller_name" => "admin")
-)
 
 # fetching boolean value feature flag
 bool_value = client.fetch_boolean_value(flag_key: 'boolean_flag', default_value: false)
@@ -75,6 +89,62 @@ integer_value = client.fetch_number_value(flag_key: 'number_value', default_valu
 
 # get an object value
 object = client.fetch_object_value(flag_key: 'object_value', default_value: JSON.dump({ name: 'object'}))
+```
+
+## 🌟 Features
+
+| Status | Features                                                            | Description                                                                                                                                                  |
+| ------ | --------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ✅      | [Providers](#providers)                                             | Integrate with a commercial, open source, or in-house feature management tool.                                                                               |
+| ✅      | [Targeting](#targeting)                                             | Contextually-aware flag evaluation using [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context).                           |
+| ⚠️      | [Hooks](#hooks)                                                     | Add functionality to various stages of the flag evaluation life-cycle.                                                                                       |
+| ❌      | [Logging](#logging)                                                 | Integrate with popular logging packages.                                                                                                                     |
+| ✅      | [Domains](#domains)                                                 | Logically bind clients with providers.                                                                                                                       |
+| ❌      | [Eventing](#eventing)                                               | React to state changes in the provider or flag management system.                                                                                            |
+| ⚠️      | [Shutdown](#shutdown)                                               | Gracefully clean up a provider during application shutdown.                                                                                                  |
+| ❌      | [Transaction Context Propagation](#transaction-context-propagation) | Set a specific [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context) for a transaction (e.g. an HTTP request or a thread) |
+| ⚠️      | [Extending](#extending)                                             | Extend OpenFeature with custom providers and hooks.                                                                                                          |
+
+<sub>Implemented: ✅ | In-progress: ⚠️ | Not implemented yet: ❌</sub>
+
+### Providers
+
+[Providers](https://openfeature.dev/docs/reference/concepts/provider) are an abstraction between a flag management system and the OpenFeature SDK.
+Look [here](https://openfeature.dev/ecosystem?instant_search%5BrefinementList%5D%5Btype%5D%5B0%5D=Provider&instant_search%5BrefinementList%5D%5Btechnology%5D%5B0%5D=ruby) for a complete list of available providers.
+If the provider you're looking for hasn't been created yet, see the [develop a provider](#develop-a-provider) section to learn how to build it yourself.
+
+Once you've added a provider as a dependency, it can be registered with OpenFeature like this:
+
+```ruby
+OpenFeature::SDK.configure do |config|
+  # your provider of choice, which will be used as the default provider
+  config.set_provider(OpenFeature::SDK::Provider::InMemoryProvider.new(
+    {
+      "v2_enabled" => true,
+    }
+  ))
+end
+```
+
+In some situations, it may be beneficial to register multiple providers in the same application.
+This is possible using [domains](#domains), which is covered in more detail below.
+
+### Targeting
+
+Sometimes, the value of a flag must consider some dynamic criteria about the application or user, such as the user's location, IP, email address, or the server's location.
+In OpenFeature, we refer to this as [targeting](https://openfeature.dev/specification/glossary#targeting).
+If the flag management system you're using supports targeting, you can provide the input data using the [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context).
+
+```ruby
+OpenFeature::SDK.configure do |config|
+  # you can set a global evaluation context here
+  config.evaluation_context = OpenFeature::SDK::EvaluationContext.new("host" => "myhost.com")
+end
+
+# Evaluation context can be set on a client as well
+client_with_context = OpenFeature::SDK.build_client(
+  evaluation_context: OpenFeature::SDK::EvaluationContext.new("controller_name" => "admin")
+)
 
 # Invocation evaluation context can also be passed in during flag evaluation.
 # During flag evaluation, invocation context takes precedence over client context
@@ -86,38 +156,159 @@ bool_value = client.fetch_boolean_value(
 )
 ```
 
-For complete documentation, visit: https://openfeature.dev/docs/category/concepts
+### Hooks
 
-### Providers
+Coming Soon!
 
-Providers are the abstraction layer between OpenFeature and different flag management systems.
+<!-- [Hooks](https://openfeature.dev/docs/reference/concepts/hooks) allow for custom logic to be added at well-defined points of the flag evaluation life-cycle.
+Look [here](https://openfeature.dev/ecosystem/?instant_search%5BrefinementList%5D%5Btype%5D%5B0%5D=Hook&instant_search%5BrefinementList%5D%5Btechnology%5D%5B0%5D=ruby) for a complete list of available hooks.
+If the hook you're looking for hasn't been created yet, see the [develop a hook](#develop-a-hook) section to learn how to build it yourself.
 
-The `NoOpProvider` is an example of a minimalist provider. The `InMemoryProvider` is a provider that can be initialized with flags and used to store flags in process. For complete documentation on the Provider interface, visit: https://openfeature.dev/specification/sections/providers.
+Once you've added a hook as a dependency, it can be registered at the global, client, or flag invocation level. -->
 
-In addition to the `fetch_*` methods, providers can optionally implement lifecycle methods that are invoked when the underlying provider is switched out. For example:
+<!-- TODO: code example of setting hooks at all levels -->
+
+### Logging
+
+Coming Soon!
+
+<!-- TODO: talk about logging config and include a code example -->
+
+### Domains
+
+Clients can be assigned to a domain. A domain is a logical identifier which can be used to associate clients with a particular provider.
+If a domain has no associated provider, the default provider is used.
+
+```ruby
+OpenFeature::SDK.configure do |config|
+  config.set_provider(OpenFeature::SDK::Provider::NoOpProvider.new, domain: "legacy_flags")
+end
+
+# Create a client for a different domain, this will use the provider assigned to that domain
+legacy_flag_client = OpenFeature::SDK.build_client(domain: "legacy_flags")
+```
+
+### Eventing
+
+Coming Soon!
+
+<!-- Events allow you to react to state changes in the provider or underlying flag management system, such as flag definition changes, provider readiness, or error conditions.
+Initialization events (`PROVIDER_READY` on success, `PROVIDER_ERROR` on failure) are dispatched for every provider.
+Some providers support additional events, such as `PROVIDER_CONFIGURATION_CHANGED`.
+
+Please refer to the documentation of the provider you're using to see what events are supported. -->
+
+<!-- TODO: code example of a PROVIDER_CONFIGURATION_CHANGED event for the client and a PROVIDER_STALE event for the API -->
+
+### Shutdown
+
+Coming Soon!
+
+<!-- TODO The OpenFeature API provides a close function to perform a cleanup of all registered providers.
+This should only be called when your application is in the process of shutting down.
+
+```ruby
+class MyProvider
+  def shutdown
+    # Perform any shutdown/reclamation steps with flag management system here
+    # Return value is ignored
+  end
+end
+``` -->
+
+### Transaction Context Propagation
+
+Coming Soon!
+
+<!-- Transaction context is a container for transaction-specific evaluation context (e.g. user id, user agent, IP).
+Transaction context can be set where specific data is available (e.g. an auth service or request handler) and by using the transaction context propagator it will automatically be applied to all flag evaluations within a transaction (e.g. a request or thread). -->
+
+<!-- TODO: code example for global shutdown -->
+
+## Extending
+
+### Develop a provider
+
+To develop a provider, you need to create a new project and include the OpenFeature SDK as a dependency.
+This can be a new repository or included in [the existing contrib repository](https://github.com/open-feature/ruby-sdk-contrib) available under the OpenFeature organization.
+You’ll then need to write the provider by implementing the `Provider` duck.
 
 ```ruby
 class MyProvider
   def init
     # Perform any initialization steps with flag management system here
     # Return value is ignored
+    # **Note** The OpenFeature spec defines a lifecycle method called `initialize` to be called when a new provider is set.
+    # To avoid conflicting with the Ruby `initialize` method, this method should be named `init` when creating a provider.
   end
 
   def shutdown
     # Perform any shutdown/reclamation steps with flag management system here
     # Return value is ignored
   end
+
+  def fetch_boolean_value(flag_key:, default_value:, evaluation_context: nil)
+    # Retrieve a boolean value from provider source
+  end
+
+  def fetch_string_value(flag_key:, default_value:, evaluation_context: nil)
+    # Retrieve a string value from provider source
+  end
+
+  def fetch_number_value(flag_key:, default_value:, evaluation_context: nil)
+    # Retrieve a numeric value from provider source
+  end
+
+  def fetch_integer_value(flag_key:, default_value:, evaluation_context: nil)
+    # Retrieve a integer value from provider source
+  end
+
+  def fetch_float_value(flag_key:, default_value:, evaluation_context: nil)
+    # Retrieve a float value from provider source
+  end
+
+  def fetch_object_value(flag_key:, default_value:, evaluation_context: nil)
+    # Retrieve a hash value from provider source
+  end
 end
 ```
 
-**Note** The OpenFeature spec defines a lifecycle method called `initialize` to be called when a new provider is set. To avoid conflicting with the Ruby `initialize` method, this method should be named `init` when creating a provider.
+> Built a new provider? [Let us know](https://github.com/open-feature/openfeature.dev/issues/new?assignees=&labels=provider&projects=&template=document-provider.yaml&title=%5BProvider%5D%3A+) so we can add it to the docs!
 
-## Contributing
+### Develop a hook
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to the OpenFeature project.
+Coming Soon!
 
-Our community meetings are held regularly and open to everyone. Check the [OpenFeature community calendar](https://calendar.google.com/calendar/u/0?cid=MHVhN2kxaGl2NWRoMThiMjd0b2FoNjM2NDRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ) for specific dates and for the Zoom meeting links.
+<!-- To develop a hook, you need to create a new project and include the OpenFeature SDK as a dependency.
+This can be a new repository or included in [the existing contrib repository](https://github.com/open-feature/ruby-sdk-contrib) available under the OpenFeature organization.
+Implement your own hook by conforming to the `Hook interface`.
+To satisfy the interface, all methods (`Before`/`After`/`Finally`/`Error`) need to be defined.
+To avoid defining empty functions, make use of the `UnimplementedHook` struct (which already implements all the empty functions). -->
 
-## License
+<!-- TODO: code example of hook implementation -->
 
-[Apache License 2.0](LICENSE)
+<!-- > Built a new hook? [Let us know](https://github.com/open-feature/openfeature.dev/issues/new?assignees=&labels=hook&projects=&template=document-hook.yaml&title=%5BHook%5D%3A+) so we can add it to the docs! -->
+
+<!-- x-hide-in-docs-start -->
+## ⭐️ Support the project
+
+- Give this repo a ⭐️!
+- Follow us on social media:
+  - Twitter: [@openfeature](https://twitter.com/openfeature)
+  - LinkedIn: [OpenFeature](https://www.linkedin.com/company/openfeature/)
+- Join us on [Slack](https://cloud-native.slack.com/archives/C0344AANLA1)
+- For more, check out our [community page](https://openfeature.dev/community/)
+
+## 🤝 Contributing
+
+Interested in contributing? Great, we'd love your help! To get started, take a look at the [CONTRIBUTING](CONTRIBUTING.md) guide.
+
+### Thanks to everyone who has already contributed
+
+<a href="https://github.com/open-feature/ruby-sdk/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=open-feature/ruby-sdk" alt="Pictures of the folks who have contributed to the project" />
+</a>
+
+
+Made with [contrib.rocks](https://contrib.rocks).
+<!-- x-hide-in-docs-end -->

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ client = OpenFeature::SDK.build_client
 # fetching boolean value feature flag
 bool_value = client.fetch_boolean_value(flag_key: 'boolean_flag', default_value: false)
 
+# a details method is also available for more information about the flag evaluation
+# see `ResolutionDetails` for more info
+bool_details = client.fetch_boolean_details(flag_key: 'boolean_flag', default_value: false) ==
+
 # fetching string value feature flag
 string_value = client.fetch_string_value(flag_key: 'string_flag', default_value: false)
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ bool_value = client.fetch_boolean_value(
 
 ### Hooks
 
-Coming Soon!
+Coming Soon! [Issue available](https://github.com/open-feature/ruby-sdk/issues/52) to be worked on.
 
 <!-- [Hooks](https://openfeature.dev/docs/reference/concepts/hooks) allow for custom logic to be added at well-defined points of the flag evaluation life-cycle.
 Look [here](https://openfeature.dev/ecosystem/?instant_search%5BrefinementList%5D%5Btype%5D%5B0%5D=Hook&instant_search%5BrefinementList%5D%5Btechnology%5D%5B0%5D=Ruby) for a complete list of available hooks.
@@ -170,7 +170,7 @@ Once you've added a hook as a dependency, it can be registered at the global, cl
 
 ### Logging
 
-Coming Soon!
+Coming Soon! [Issue available](https://github.com/open-feature/ruby-sdk/issues/148) to work on.
 
 <!-- TODO: talk about logging config and include a code example -->
 
@@ -190,7 +190,7 @@ legacy_flag_client = OpenFeature::SDK.build_client(domain: "legacy_flags")
 
 ### Eventing
 
-Coming Soon!
+Coming Soon! [Issue available](https://github.com/open-feature/ruby-sdk/issues/51) to be worked on.
 
 <!-- Events allow you to react to state changes in the provider or underlying flag management system, such as flag definition changes, provider readiness, or error conditions.
 Initialization events (`PROVIDER_READY` on success, `PROVIDER_ERROR` on failure) are dispatched for every provider.
@@ -202,7 +202,7 @@ Please refer to the documentation of the provider you're using to see what event
 
 ### Shutdown
 
-Coming Soon!
+Coming Soon! [Issue available](https://github.com/open-feature/ruby-sdk/issues/149) to be worked on.
 
 <!-- TODO The OpenFeature API provides a close function to perform a cleanup of all registered providers.
 This should only be called when your application is in the process of shutting down.
@@ -218,7 +218,7 @@ end
 
 ### Transaction Context Propagation
 
-Coming Soon!
+Coming Soon! [Issue available](https://github.com/open-feature/ruby-sdk/issues/150) to be worked on.
 
 <!-- Transaction context is a container for transaction-specific evaluation context (e.g. user id, user agent, IP).
 Transaction context can be set where specific data is available (e.g. an auth service or request handler) and by using the transaction context propagator it will automatically be applied to all flag evaluations within a transaction (e.g. a request or thread). -->
@@ -277,7 +277,7 @@ end
 
 ### Develop a hook
 
-Coming Soon!
+Coming Soon! [Issue available](https://github.com/open-feature/ruby-sdk/issues/52) to be worked on.
 
 <!-- To develop a hook, you need to create a new project and include the OpenFeature SDK as a dependency.
 This can be a new repository or included in [the existing contrib repository](https://github.com/open-feature/ruby-sdk-contrib) available under the OpenFeature organization.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,10 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "package-name": "openfeature-sdk",
-      "version-file": "lib/open_feature/sdk/version.rb"
+      "version-file": "lib/open_feature/sdk/version.rb",
+      "extra-files": [
+        "README.md"
+      ]
     }
   }
 }


### PR DESCRIPTION
## This PR

- adds a basic `CONTRIBUTING.md` file
- updates `README.md` to match OF template and be parseable by release-please

### Related Issues
Closes #120 
Closes #45 

### Follow-up Tasks
* Once this is released, will open a PR to have the `ruby-sdk` listed on the OF website