### PR TITLE
refactor: satisfy requirement 1.3.4

### DIFF
--- a/lib/open_feature/sdk/client.rb
+++ b/lib/open_feature/sdk/client.rb
@@ -5,7 +5,15 @@ module OpenFeature
     # TODO: Write documentation
     #
     class Client
-      RESULT_TYPE = %i[boolean string number integer float object].freeze
+      TYPE_CLASS_MAP = {
+        boolean: [TrueClass, FalseClass],
+        string: [String],
+        number: [Numeric],
+        integer: [Integer],
+        float: [Float],
+        object: [Array, Hash]
+      }.freeze
+      RESULT_TYPE = TYPE_CLASS_MAP.keys.freeze
       SUFFIXES = %i[value details].freeze
 
       attr_reader :metadata, :evaluation_context
@@ -26,13 +34,27 @@ module OpenFeature
             #   result = @provider.fetch_boolean_value(flag_key: flag_key, default_value: default_value, evaluation_context: evaluation_context)
             # end
             def fetch_#{result_type}_#{suffix}(flag_key:, default_value:, evaluation_context: nil)
-              built_context = EvaluationContextBuilder.new.call(api_context: OpenFeature::SDK.evaluation_context, client_context: self.evaluation_context, invocation_context: evaluation_context)
-              resolution_details = @provider.fetch_#{result_type}_value(flag_key:, default_value:, evaluation_context: built_context)
-              evaluation_details = EvaluationDetails.new(flag_key:, resolution_details:)
+              evaluation_details = fetch_details(type: :#{result_type}, flag_key:, default_value:, evaluation_context:)
               #{"evaluation_details.value" if suffix == :value}
             end
           RUBY
         end
+      end
+
+      private
+
+      def fetch_details(type:, flag_key:, default_value:, evaluation_context: nil)
+        built_context = EvaluationContextBuilder.new.call(api_context: OpenFeature::SDK.evaluation_context, client_context: self.evaluation_context, invocation_context: evaluation_context)
+
+        resolution_details = @provider.send(:"fetch_#{type}_value", flag_key:, default_value:, evaluation_context: built_context)
+        
+        if TYPE_CLASS_MAP[type].none? { |klass| resolution_details.value.is_a?(klass) }
+          resolution_details.value = default_value
+          resolution_details.error_code = Provider::ErrorCode::TYPE_MISMATCH
+          resolution_details.reason = Provider::Reason::ERROR
+        end
+
+        EvaluationDetails.new(flag_key:, resolution_details:)
       end
     end
   end

--- a/lib/open_feature/sdk/client.rb
+++ b/lib/open_feature/sdk/client.rb
@@ -47,7 +47,7 @@ module OpenFeature
         built_context = EvaluationContextBuilder.new.call(api_context: OpenFeature::SDK.evaluation_context, client_context: self.evaluation_context, invocation_context: evaluation_context)
 
         resolution_details = @provider.send(:"fetch_#{type}_value", flag_key:, default_value:, evaluation_context: built_context)
-        
+
         if TYPE_CLASS_MAP[type].none? { |klass| resolution_details.value.is_a?(klass) }
           resolution_details.value = default_value
           resolution_details.error_code = Provider::ErrorCode::TYPE_MISMATCH

--- a/lib/open_feature/sdk/provider/in_memory_provider.rb
+++ b/lib/open_feature/sdk/provider/in_memory_provider.rb
@@ -26,45 +26,41 @@ module OpenFeature
         end
 
         def fetch_boolean_value(flag_key:, default_value:, evaluation_context: nil)
-          fetch_value(allowed_classes: [TrueClass, FalseClass], flag_key:, default_value:, evaluation_context:)
+          fetch_value(flag_key:, default_value:, evaluation_context:)
         end
 
         def fetch_string_value(flag_key:, default_value:, evaluation_context: nil)
-          fetch_value(allowed_classes: [String], flag_key:, default_value:, evaluation_context:)
+          fetch_value(flag_key:, default_value:, evaluation_context:)
         end
 
         def fetch_number_value(flag_key:, default_value:, evaluation_context: nil)
-          fetch_value(allowed_classes: [Numeric], flag_key:, default_value:, evaluation_context:)
+          fetch_value(flag_key:, default_value:, evaluation_context:)
         end
 
         def fetch_integer_value(flag_key:, default_value:, evaluation_context: nil)
-          fetch_value(allowed_classes: [Integer], flag_key:, default_value:, evaluation_context:)
+          fetch_value(flag_key:, default_value:, evaluation_context:)
         end
 
         def fetch_float_value(flag_key:, default_value:, evaluation_context: nil)
-          fetch_value(allowed_classes: [Float], flag_key:, default_value:, evaluation_context:)
+          fetch_value(flag_key:, default_value:, evaluation_context:)
         end
 
         def fetch_object_value(flag_key:, default_value:, evaluation_context: nil)
-          fetch_value(allowed_classes: [Array, Hash], flag_key:, default_value:, evaluation_context:)
+          fetch_value(flag_key:, default_value:, evaluation_context:)
         end
 
         private
 
         attr_reader :flags
 
-        def fetch_value(allowed_classes:, flag_key:, default_value:, evaluation_context:)
+        def fetch_value(flag_key:, default_value:, evaluation_context:)
           value = flags[flag_key]
 
           if value.nil?
             return ResolutionDetails.new(value: default_value, error_code: ErrorCode::FLAG_NOT_FOUND, reason: Reason::ERROR)
           end
 
-          if allowed_classes.any? { |klass| value.is_a?(klass) }
-            ResolutionDetails.new(value:, reason: Reason::STATIC)
-          else
-            ResolutionDetails.new(value: default_value, error_code: ErrorCode::TYPE_MISMATCH, reason: Reason::ERROR)
-          end
+          ResolutionDetails.new(value:, reason: Reason::STATIC)
         end
       end
     end

--- a/spec/open_feature/sdk/client_spec.rb
+++ b/spec/open_feature/sdk/client_spec.rb
@@ -110,13 +110,13 @@ RSpec.describe OpenFeature::SDK::Client do
               "num" => true,
               "int" => "one",
               "float" => "1.23",
-              "obj" => "{}",
+              "obj" => "{}"
             }
           )
         end
 
         context "boolean value" do
-          let(:flag_key) { "bool"}
+          let(:flag_key) { "bool" }
           let(:default_value) { false }
 
           it "returns default as type mismatch" do

--- a/spec/open_feature/sdk/client_spec.rb
+++ b/spec/open_feature/sdk/client_spec.rb
@@ -100,6 +100,101 @@ RSpec.describe OpenFeature::SDK::Client do
       pending
     end
 
+    context "Requirement 1.3.4" do
+      context "Guarantee the returned value of any typed flag evaluation method is of the expected type. If the value returned by the underlying provider implementation does not match the expected type, it's to be considered abnormal execution, and the supplied default value should be returned." do
+        let(:provider) do
+          OpenFeature::SDK::Provider::InMemoryProvider.new(
+            {
+              "bool" => "no",
+              "str" => 123,
+              "num" => true,
+              "int" => "one",
+              "float" => "1.23",
+              "obj" => "{}",
+            }
+          )
+        end
+
+        context "boolean value" do
+          let(:flag_key) { "bool"}
+          let(:default_value) { false }
+
+          it "returns default as type mismatch" do
+            fetched = client.fetch_boolean_details(flag_key:, default_value:)
+
+            expect(fetched.value).to be(default_value)
+            expect(fetched.error_code).to eq(OpenFeature::SDK::Provider::ErrorCode::TYPE_MISMATCH)
+            expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::ERROR)
+          end
+        end
+
+        context "string value" do
+          let(:flag_key) { "str" }
+          let(:default_value) { "default" }
+
+          it "returns default as type mismatch" do
+            fetched = client.fetch_string_details(flag_key:, default_value:)
+
+            expect(fetched.value).to be(default_value)
+            expect(fetched.error_code).to eq(OpenFeature::SDK::Provider::ErrorCode::TYPE_MISMATCH)
+            expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::ERROR)
+          end
+        end
+
+        context "number value" do
+          let(:flag_key) { "num" }
+          let(:default_value) { 4 }
+
+          it "returns default as type mismatch" do
+            fetched = client.fetch_number_details(flag_key:, default_value:)
+
+            expect(fetched.value).to be(default_value)
+            expect(fetched.error_code).to eq(OpenFeature::SDK::Provider::ErrorCode::TYPE_MISMATCH)
+            expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::ERROR)
+          end
+        end
+
+        context "integer value" do
+          let(:flag_key) { "int" }
+          let(:default_value) { 4 }
+
+          it "returns default as type mismatch" do
+            fetched = client.fetch_integer_details(flag_key:, default_value:)
+
+            expect(fetched.value).to be(default_value)
+            expect(fetched.error_code).to eq(OpenFeature::SDK::Provider::ErrorCode::TYPE_MISMATCH)
+            expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::ERROR)
+          end
+        end
+
+        context "float value" do
+          let(:flag_key) { "float" }
+          let(:default_value) { 1.23 }
+
+          it "returns default as type mismatch" do
+            fetched = client.fetch_float_details(flag_key:, default_value:)
+
+            expect(fetched.value).to be(default_value)
+            expect(fetched.error_code).to eq(OpenFeature::SDK::Provider::ErrorCode::TYPE_MISMATCH)
+            expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::ERROR)
+          end
+        end
+
+        context "object value" do
+          let(:flag_key) { "obj" }
+          let(:default_value) { {} }
+
+          it "returns default as type mismatch" do
+            fetched = client.fetch_object_details(flag_key:, default_value:)
+
+            expect(fetched.value).to be(default_value)
+            expect(fetched.error_code).to eq(OpenFeature::SDK::Provider::ErrorCode::TYPE_MISMATCH)
+            expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::ERROR)
+          end
+        end
+      end
+    end
+
     context "Detailed Feature Evaluation" do
       let(:flag_key) { "my-awesome-feature-flag-key" }
 

--- a/spec/open_feature/sdk/provider/in_memory_provider_spec.rb
+++ b/spec/open_feature/sdk/provider/in_memory_provider_spec.rb
@@ -37,23 +37,11 @@ RSpec.describe OpenFeature::SDK::Provider::InMemoryProvider do
 
   describe "#fetch_boolean_value" do
     context "when flag is found" do
-      context "when type matches" do
-        it "returns value as static" do
-          fetched = provider.fetch_boolean_value(flag_key: "bool", default_value: false)
+      it "returns value as static" do
+        fetched = provider.fetch_boolean_value(flag_key: "bool", default_value: false)
 
-          expect(fetched.value).to eq(true)
-          expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::STATIC)
-        end
-      end
-
-      context "when type does not match" do
-        it "returns default as type mismatch" do
-          fetched = provider.fetch_boolean_value(flag_key: "str", default_value: false)
-
-          expect(fetched.value).to eq(false)
-          expect(fetched.error_code).to eq(OpenFeature::SDK::Provider::ErrorCode::TYPE_MISMATCH)
-          expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::ERROR)
-        end
+        expect(fetched.value).to eq(true)
+        expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::STATIC)
       end
     end
 
@@ -70,23 +58,11 @@ RSpec.describe OpenFeature::SDK::Provider::InMemoryProvider do
 
   describe "#fetch_string_value" do
     context "when flag is found" do
-      context "when type matches" do
-        it "returns value as static" do
-          fetched = provider.fetch_string_value(flag_key: "str", default_value: "fallback")
+      it "returns value as static" do
+        fetched = provider.fetch_string_value(flag_key: "str", default_value: "fallback")
 
-          expect(fetched.value).to eq("testing")
-          expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::STATIC)
-        end
-      end
-
-      context "when type does not match" do
-        it "returns default as type mismatch" do
-          fetched = provider.fetch_string_value(flag_key: "bool", default_value: "fallback")
-
-          expect(fetched.value).to eq("fallback")
-          expect(fetched.error_code).to eq(OpenFeature::SDK::Provider::ErrorCode::TYPE_MISMATCH)
-          expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::ERROR)
-        end
+        expect(fetched.value).to eq("testing")
+        expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::STATIC)
       end
     end
 
@@ -103,29 +79,17 @@ RSpec.describe OpenFeature::SDK::Provider::InMemoryProvider do
 
   describe "#fetch_number_value" do
     context "when flag is found" do
-      context "when type matches" do
-        it "returns int as static" do
-          fetched = provider.fetch_number_value(flag_key: "int", default_value: 0)
+      it "returns int as static" do
+        fetched = provider.fetch_number_value(flag_key: "int", default_value: 0)
 
-          expect(fetched.value).to eq(1)
-          expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::STATIC)
-        end
-        it "returns float as static" do
-          fetched = provider.fetch_number_value(flag_key: "float", default_value: 0.0)
-
-          expect(fetched.value).to eq(1.0)
-          expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::STATIC)
-        end
+        expect(fetched.value).to eq(1)
+        expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::STATIC)
       end
+      it "returns float as static" do
+        fetched = provider.fetch_number_value(flag_key: "float", default_value: 0.0)
 
-      context "when type does not match" do
-        it "returns default as type mismatch" do
-          fetched = provider.fetch_number_value(flag_key: "str", default_value: 0)
-
-          expect(fetched.value).to eq(0)
-          expect(fetched.error_code).to eq(OpenFeature::SDK::Provider::ErrorCode::TYPE_MISMATCH)
-          expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::ERROR)
-        end
+        expect(fetched.value).to eq(1.0)
+        expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::STATIC)
       end
     end
 
@@ -142,29 +106,17 @@ RSpec.describe OpenFeature::SDK::Provider::InMemoryProvider do
 
   describe "#fetch_integer_value" do
     context "when flag is found" do
-      context "when type matches" do
-        it "returns value as static" do
-          fetched = provider.fetch_integer_value(flag_key: "int", default_value: 0)
+      it "returns value as static" do
+        fetched = provider.fetch_integer_value(flag_key: "int", default_value: 0)
 
-          expect(fetched.value).to eq(1)
-          expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::STATIC)
-        end
-      end
-
-      context "when type does not match" do
-        it "returns default as type mismatch" do
-          fetched = provider.fetch_integer_value(flag_key: "float", default_value: 0)
-
-          expect(fetched.value).to eq(0)
-          expect(fetched.error_code).to eq(OpenFeature::SDK::Provider::ErrorCode::TYPE_MISMATCH)
-          expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::ERROR)
-        end
+        expect(fetched.value).to eq(1)
+        expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::STATIC)
       end
     end
 
     context "when flag is not found" do
       it "returns default as flag not found" do
-        fetched = provider.fetch_number_value(flag_key: "not here", default_value: 0)
+        fetched = provider.fetch_integer_value(flag_key: "not here", default_value: 0)
 
         expect(fetched.value).to eq(0)
         expect(fetched.error_code).to eq(OpenFeature::SDK::Provider::ErrorCode::FLAG_NOT_FOUND)
@@ -173,31 +125,19 @@ RSpec.describe OpenFeature::SDK::Provider::InMemoryProvider do
     end
   end
 
-  describe "#fetch_integer_value" do
+  describe "#fetch_float_value" do
     context "when flag is found" do
-      context "when type matches" do
-        it "returns value as static" do
-          fetched = provider.fetch_float_value(flag_key: "float", default_value: 0.0)
+      it "returns value as static" do
+        fetched = provider.fetch_float_value(flag_key: "float", default_value: 0.0)
 
-          expect(fetched.value).to eq(1.0)
-          expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::STATIC)
-        end
-      end
-
-      context "when type does not match" do
-        it "returns default as type mismatch" do
-          fetched = provider.fetch_float_value(flag_key: "int", default_value: 0.0)
-
-          expect(fetched.value).to eq(0)
-          expect(fetched.error_code).to eq(OpenFeature::SDK::Provider::ErrorCode::TYPE_MISMATCH)
-          expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::ERROR)
-        end
+        expect(fetched.value).to eq(1.0)
+        expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::STATIC)
       end
     end
 
     context "when flag is not found" do
       it "returns default as flag not found" do
-        fetched = provider.fetch_number_value(flag_key: "not here", default_value: 0)
+        fetched = provider.fetch_float_value(flag_key: "not here", default_value: 0)
 
         expect(fetched.value).to eq(0)
         expect(fetched.error_code).to eq(OpenFeature::SDK::Provider::ErrorCode::FLAG_NOT_FOUND)
@@ -208,23 +148,11 @@ RSpec.describe OpenFeature::SDK::Provider::InMemoryProvider do
 
   describe "#fetch_object_value" do
     context "when flag is found" do
-      context "when type matches" do
-        it "returns value as static" do
-          fetched = provider.fetch_object_value(flag_key: "struct", default_value: {})
+      it "returns value as static" do
+        fetched = provider.fetch_object_value(flag_key: "struct", default_value: {})
 
-          expect(fetched.value).to eq({"more" => "config"})
-          expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::STATIC)
-        end
-      end
-
-      context "when type does not match" do
-        it "returns default as type mismatch" do
-          fetched = provider.fetch_object_value(flag_key: "int", default_value: {})
-
-          expect(fetched.value).to eq({})
-          expect(fetched.error_code).to eq(OpenFeature::SDK::Provider::ErrorCode::TYPE_MISMATCH)
-          expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::ERROR)
-        end
+        expect(fetched.value).to eq({"more" => "config"})
+        expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::STATIC)
       end
     end
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->
- Moves the type verification from `InMemoryProvider` into `Client` to satisfy [Requirement 1.3.4](https://openfeature.dev/specification/sections/flag-evaluation/#requirement-134)

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #126

### Notes
<!-- any additional notes for this PR -->
This seemed like a good issue to attempt to tackle as my first contribution. I'm unsure on if the implementation matches what was expected, so feedback is very welcome here!