### PR TITLE
ci: split release please check from gem publish

### DIFF
--- a/.github/workflows/gem-release.yml
+++ b/.github/workflows/gem-release.yml
@@ -25,9 +25,7 @@ jobs:
 
       - name: Release Gem
         run: |
-          gem install bundler
           bundle config unset deployment
-          bundle install
           mkdir -p $HOME/.gem
           touch $HOME/.gem/credentials
           chmod 0600 $HOME/.gem/credentials

--- a/.github/workflows/gem-release.yml
+++ b/.github/workflows/gem-release.yml
@@ -1,0 +1,36 @@
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. v0.6.5)"
+        required: true
+        type: string
+
+name: Publish Gem
+jobs:
+  gem-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+
+      - uses: ruby/setup-ruby@v1
+      - run: bundle install
+
+      - name: Release Gem
+        run: |
+          gem install bundler
+          bundle config unset deployment
+          bundle install
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${RUBY_GEM_API_TOKEN}\n" > $HOME/.gem/credentials
+          gem build *.gemspec
+          gem push *.gem
+        env:
+          RUBY_GEM_API_TOKEN: "${{secrets.RUBY_GEM_API_TOKEN}}"

--- a/.github/workflows/gem-release.yml
+++ b/.github/workflows/gem-release.yml
@@ -9,6 +9,8 @@ on:
         type: string
 
 name: Publish Gem
+permissions:
+  contents: read
 jobs:
   gem-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,35 +17,3 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_ACTION_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      release_tag_name: ${{ steps.release.outputs.tag_name }}
-
-  gem-release:
-    needs: release-please
-    runs-on: ubuntu-latest
-    if: ${{ needs.release-please.outputs.release_created }}
-    steps:
-      # The logic below handles the npm publication:
-      - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ needs.release-please.outputs.release_tag_name }}
-
-      # Set up Ruby if a release can be created.
-      - uses: ruby/setup-ruby@v1
-      - run: bundle install
-
-      - name: Release Gem
-        run: |
-          gem install bundler
-          bundle config unset deployment
-          bundle install
-          mkdir -p $HOME/.gem
-          touch $HOME/.gem/credentials
-          chmod 0600 $HOME/.gem/credentials
-          printf -- "---\n:rubygems_api_key: ${RUBY_GEM_API_TOKEN}\n" > $HOME/.gem/credentials
-          gem build *.gemspec
-          gem push *.gem
-        env:
-          RUBY_GEM_API_TOKEN: "${{secrets.RUBY_GEM_API_TOKEN}}"


### PR DESCRIPTION
## This PR

Splits the Release Please action from the Gem Publishing step. This allows us to rerun the publishing step if it fails for any reason.

### Notes

Here's a real world situation where the release failed due to an auth issue and rerunning the workflow skipped the publishing step.