### PR TITLE
ci: use oidc publishing

### DIFF
--- a/.github/workflows/gem-release.yml
+++ b/.github/workflows/gem-release.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name || inputs.tag }}
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
       - run: bundle install
 
       - name: Build Gem
@@ -36,4 +36,4 @@ jobs:
           gem build "${gemspecs[0]}"
 
       - name: Push Gem
-        uses: rubygems/release-gem@v1
+        uses: rubygems/release-gem@6317d8d1f7e28c24d28f6eff169ea854948bd9f7 # v1.2.0

--- a/.github/workflows/gem-release.yml
+++ b/.github/workflows/gem-release.yml
@@ -27,7 +27,13 @@ jobs:
       - run: bundle install
 
       - name: Build Gem
-        run: gem build *.gemspec
+        run: |
+          mapfile -t gemspecs < <(find . -maxdepth 1 -type f -name '*.gemspec' -printf '%f\n' | sort)
+          if [ "${#gemspecs[@]}" -ne 1 ]; then
+            echo "Expected exactly one gemspec in the repository root, found ${#gemspecs[@]}: ${gemspecs[*]}" >&2
+            exit 1
+          fi
+          gem build "${gemspecs[0]}"
 
       - name: Push Gem
         uses: rubygems/release-gem@v1

--- a/.github/workflows/gem-release.yml
+++ b/.github/workflows/gem-release.yml
@@ -9,8 +9,11 @@ on:
         type: string
 
 name: Publish Gem
+
 permissions:
   contents: read
+  id-token: write
+
 jobs:
   gem-release:
     runs-on: ubuntu-latest
@@ -23,14 +26,8 @@ jobs:
       - uses: ruby/setup-ruby@v1
       - run: bundle install
 
-      - name: Release Gem
-        run: |
-          bundle config unset deployment
-          mkdir -p $HOME/.gem
-          touch $HOME/.gem/credentials
-          chmod 0600 $HOME/.gem/credentials
-          printf -- "---\n:rubygems_api_key: ${RUBY_GEM_API_TOKEN}\n" > $HOME/.gem/credentials
-          gem build *.gemspec
-          gem push *.gem
-        env:
-          RUBY_GEM_API_TOKEN: "${{secrets.RUBY_GEM_API_TOKEN}}"
+      - name: Build Gem
+        run: gem build *.gemspec
+
+      - name: Push Gem
+        uses: rubygems/release-gem@v1


### PR DESCRIPTION
Switch to OIDC Gem publishing instead of token-based.

https://guides.rubygems.org/trusted-publishing/