### PR TITLE
fix: use provider object as hash key in ProviderStateRegistry

### DIFF
--- a/features/step_definitions/evaluation_steps.rb
+++ b/features/step_definitions/evaluation_steps.rb
@@ -17,11 +17,8 @@ Given(/^a (stable|not ready|error|fatal|stale) provider$/) do |status|
     when "stale" then OpenFeature::SDK::ProviderState::STALE
     end
 
-    registry = OpenFeature::SDK.configuration.send(:instance_variable_get, :@provider_state_registry)
-    registry.send(:instance_variable_get, :@mutex).synchronize do
-      states = registry.send(:instance_variable_get, :@states)
-      states[provider.object_id] = {state: state, details: {}}
-    end
+    registry = OpenFeature::SDK.configuration.instance_variable_get(:@provider_state_registry)
+    registry.set_initial_state(provider, state)
 
     @provider = provider
   end

--- a/lib/open_feature/sdk/provider_state_registry.rb
+++ b/lib/open_feature/sdk/provider_state_registry.rb
@@ -9,7 +9,7 @@ module OpenFeature
     # Tracks provider states
     class ProviderStateRegistry
       def initialize
-        @states = {}
+        @states = {}.compare_by_identity
         @mutex = Mutex.new
       end
 
@@ -17,7 +17,7 @@ module OpenFeature
         return unless provider
 
         @mutex.synchronize do
-          @states[provider.object_id] = {state: state, details: {}}
+          @states[provider] = {state: state, details: {}}
         end
       end
 
@@ -29,7 +29,7 @@ module OpenFeature
         # Only update state if the event should cause a state change
         if new_state
           @mutex.synchronize do
-            @states[provider.object_id] = {state: new_state, details: event_details || {}}
+            @states[provider] = {state: new_state, details: event_details || {}}
           end
           new_state
         else
@@ -42,7 +42,7 @@ module OpenFeature
         return ProviderState::NOT_READY unless provider
 
         @mutex.synchronize do
-          entry = @states[provider.object_id]
+          entry = @states[provider]
           entry ? entry[:state] : ProviderState::NOT_READY
         end
       end
@@ -51,7 +51,7 @@ module OpenFeature
         return {} unless provider
 
         @mutex.synchronize do
-          entry = @states[provider.object_id]
+          entry = @states[provider]
           entry ? entry[:details] : {}
         end
       end
@@ -60,7 +60,7 @@ module OpenFeature
         return unless provider
 
         @mutex.synchronize do
-          @states.delete(provider.object_id)
+          @states.delete(provider)
         end
       end
 
@@ -68,7 +68,7 @@ module OpenFeature
         return false unless provider
 
         @mutex.synchronize do
-          @states.key?(provider.object_id)
+          @states.key?(provider)
         end
       end
 

--- a/spec/open_feature/sdk/provider_state_registry_spec.rb
+++ b/spec/open_feature/sdk/provider_state_registry_spec.rb
@@ -7,8 +7,8 @@ require "open_feature/sdk/provider_event"
 
 RSpec.describe OpenFeature::SDK::ProviderStateRegistry do
   let(:registry) { described_class.new }
-  let(:provider) { double("Provider", object_id: 12_345) }
-  let(:provider2) { double("Provider2", object_id: 67_890) }
+  let(:provider) { double("Provider") }
+  let(:provider2) { double("Provider2") }
 
   describe "#set_initial_state" do
     it "sets NOT_READY as default state" do


### PR DESCRIPTION
## Summary

- Replace `provider.object_id` as the hash key in `ProviderStateRegistry` with `compare_by_identity`, making the internal `@states` hash use object identity for key lookup
- Remove the now-unnecessary `object_id:` stubs from test doubles in `provider_state_registry_spec.rb`

## Motivation

The original code used `provider.object_id` as an integer key to track provider state by identity. This caused Ruby 4.0 warnings in tests:

```
warning: redefining 'object_id' may cause serious problems
```

Using `{}.compare_by_identity` is the idiomatic solution, it preserves the original semantics without calling `object_id` at all.