### PR TITLE
fix: align NoOpProvider reason and ProviderInitializationError default error code with spec

### DIFF
--- a/lib/open_feature/sdk/provider/no_op_provider.rb
+++ b/lib/open_feature/sdk/provider/no_op_provider.rb
@@ -23,7 +23,7 @@ module OpenFeature
       # * <tt>fetch_object_value</tt> - Retrieve feature flag object value
       #
       class NoOpProvider
-        REASON_NO_OP = "No-op"
+        REASON_NO_OP = Reason::DEFAULT
         NAME = "No-op Provider"
 
         attr_reader :metadata

--- a/lib/open_feature/sdk/provider_initialization_error.rb
+++ b/lib/open_feature/sdk/provider_initialization_error.rb
@@ -21,8 +21,8 @@ module OpenFeature
       # @param message [String] the error message
       # @param provider [Object] the provider that failed to initialize
       # @param original_error [Exception] the original error that caused the failure
-      # @param error_code [String] the OpenFeature error code (defaults to PROVIDER_FATAL)
-      def initialize(message, provider: nil, original_error: nil, error_code: Provider::ErrorCode::PROVIDER_FATAL)
+      # @param error_code [String] the OpenFeature error code (defaults to GENERAL)
+      def initialize(message, provider: nil, original_error: nil, error_code: Provider::ErrorCode::GENERAL)
         super(message)
         @provider = provider
         @original_error = original_error

--- a/spec/open_feature/sdk/hooks/logging_hook_spec.rb
+++ b/spec/open_feature/sdk/hooks/logging_hook_spec.rb
@@ -148,12 +148,15 @@ RSpec.describe OpenFeature::SDK::Hooks::LoggingHook do
     end
 
     it "uses error_code from exception when available" do
-      error_with_code = OpenFeature::SDK::ProviderInitializationError.new("init failed")
+      error_with_code = OpenFeature::SDK::ProviderInitializationError.new(
+        "init failed",
+        error_code: "CUSTOM_ERROR_CODE"
+      )
       hook = described_class.new(logger: logger)
 
       expect(logger).to receive(:error) do |&block|
         message = block.call
-        expect(message).to include("error_code=PROVIDER_FATAL")
+        expect(message).to include("error_code=CUSTOM_ERROR_CODE")
       end
 
       hook.error(hook_context: hook_context, exception: error_with_code, hints: hints)

--- a/spec/open_feature/sdk/provider_initialization_error_spec.rb
+++ b/spec/open_feature/sdk/provider_initialization_error_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe OpenFeature::SDK::ProviderInitializationError do
         expect(error).to be_a(StandardError)
       end
 
-      it "sets the error code to PROVIDER_FATAL by default" do
-        expect(error.error_code).to eq(OpenFeature::SDK::Provider::ErrorCode::PROVIDER_FATAL)
+      it "sets the error code to GENERAL by default" do
+        expect(error.error_code).to eq(OpenFeature::SDK::Provider::ErrorCode::GENERAL)
       end
     end
 
@@ -49,8 +49,8 @@ RSpec.describe OpenFeature::SDK::ProviderInitializationError do
         expect(error.original_error).to be_nil
       end
 
-      it "sets the error code to PROVIDER_FATAL by default" do
-        expect(error.error_code).to eq(OpenFeature::SDK::Provider::ErrorCode::PROVIDER_FATAL)
+      it "sets the error code to GENERAL by default" do
+        expect(error.error_code).to eq(OpenFeature::SDK::Provider::ErrorCode::GENERAL)
       end
     end
 


### PR DESCRIPTION
## Summary

- **NoOpProvider reason**: was returning `"No-op"` as the evaluation reason. Per spec [Requirement 2.2.5](https://openfeature.dev/specification/sections/providers#requirement-225), providers SHOULD use `"DEFAULT"` when returning the default/fallback value — changed to `Provider::Reason::DEFAULT`.
- **ProviderInitializationError default**: was defaulting to `PROVIDER_FATAL` error code. Per the spec, `PROVIDER_FATAL` is reserved for irrecoverable failures that permanently prevent flag evaluation. `GENERAL` is the appropriate default for bare instantiation where no specific error code is known.