### PR TITLE
fix: do not mutate provider's ResolutionDetails on type mismatch

### DIFF
--- a/lib/open_feature/sdk/client.rb
+++ b/lib/open_feature/sdk/client.rb
@@ -155,10 +155,11 @@ module OpenFeature
         )
 
         if TYPE_CLASS_MAP[type].none? { |klass| resolution_details.value.is_a?(klass) }
-          resolution_details.value = default_value
-          resolution_details.error_code = Provider::ErrorCode::TYPE_MISMATCH
-          resolution_details.reason = Provider::Reason::ERROR
-          resolution_details.variant = nil
+          resolution_details = Provider::ResolutionDetails.new(
+            value: default_value,
+            error_code: Provider::ErrorCode::TYPE_MISMATCH,
+            reason: Provider::Reason::ERROR
+          )
         end
 
         EvaluationDetails.new(flag_key: flag_key, resolution_details: resolution_details)

--- a/spec/open_feature/sdk/client_spec.rb
+++ b/spec/open_feature/sdk/client_spec.rb
@@ -192,6 +192,22 @@ RSpec.describe OpenFeature::SDK::Client do
             expect(fetched.reason).to eq(OpenFeature::SDK::Provider::Reason::ERROR)
           end
         end
+
+        it "does not mutate the provider's ResolutionDetails on type mismatch" do
+          original = OpenFeature::SDK::Provider::ResolutionDetails.new(
+            value: "not_a_boolean",
+            reason: OpenFeature::SDK::Provider::Reason::STATIC
+          )
+          caching_provider = instance_double(OpenFeature::SDK::Provider::NoOpProvider)
+          allow(caching_provider).to receive(:fetch_boolean_value).and_return(original)
+
+          caching_client = described_class.new(provider: caching_provider)
+          caching_client.fetch_boolean_details(flag_key: "flag", default_value: false)
+
+          expect(original.value).to eq("not_a_boolean")
+          expect(original.error_code).to be_nil
+          expect(original.reason).to eq(OpenFeature::SDK::Provider::Reason::STATIC)
+        end
       end
     end
 


### PR DESCRIPTION
The spec does not prohibit providers from caching the `ResolutionDetails` they return. Mutating that object in place would cause silent data corruption for any provider that reuses it across calls — the provider owns what it returns, the SDK should not write to it.

Construct a fresh `ResolutionDetails` instead of mutating the one returned by the provider.