### PR TITLE
fix: freeze ClientMetadata to satisfy spec req 4.2.2.1

### DIFF
--- a/lib/open_feature/sdk/client_metadata.rb
+++ b/lib/open_feature/sdk/client_metadata.rb
@@ -4,6 +4,11 @@ module OpenFeature
   module SDK
     ClientMetadata = Struct.new(:domain, keyword_init: true) do
       alias_method :name, :domain
+
+      def initialize(domain: nil)
+        super(domain: domain&.dup&.freeze)
+        freeze
+      end
     end
   end
 end

--- a/spec/open_feature/sdk/client_spec.rb
+++ b/spec/open_feature/sdk/client_spec.rb
@@ -28,6 +28,11 @@ RSpec.describe OpenFeature::SDK::Client do
       expect(client).to respond_to(:metadata)
       expect(client.metadata.domain).to eq(domain)
     end
+
+    it "client metadata is frozen (req 4.2.2.1 — hook context client_metadata must be immutable)" do
+      expect(client.metadata).to be_frozen
+      expect(client.metadata.domain).to be_frozen
+    end
   end
 
   context "Flag evaluation" do


### PR DESCRIPTION
Spec requirement 4.2.2.1 states that `client_metadata` in `HookContext` MUST be immutable.

`ClientMetadata` was an unfrozen Struct — any hook could mutate it, corrupting the client's `@metadata` for all subsequent evaluations since the same object is shared across hook invocations.

Adds `.freeze` at construction, consistent with how both built-in providers already handle `ProviderMetadata`.