### PR TITLE
docs: fix inaccuracies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ gem install openfeature-sdk
 
 ```ruby
 require 'open_feature/sdk'
-require 'json' # For JSON.dump
 
 # API Initialization and configuration
 
@@ -91,7 +90,7 @@ client = OpenFeature::SDK.build_client
 bool_value = client.fetch_boolean_value(flag_key: 'boolean_flag', default_value: false)
 
 # a details method is also available for more information about the flag evaluation
-# see `ResolutionDetails` for more info
+# see `EvaluationDetails` for more info
 bool_details = client.fetch_boolean_details(flag_key: 'boolean_flag', default_value: false)
 
 # fetching string value feature flag


### PR DESCRIPTION
## Summary

- Fix minor accuracy issues in the README

## Changes

1. **Quick start**: Removed unused `require 'json' # For JSON.dump` line. The comment claims it's for `JSON.dump`, but no `JSON.dump` (or any other `JSON` method) is called anywhere in the quick start code block
2. **fetch_boolean_details comment**: Fixed `# see ResolutionDetails for more info` to `EvaluationDetails`. The `fetch_*_details` methods return an `EvaluationDetails` instance (which wraps a `ResolutionDetails` internally), not a `ResolutionDetails` directly