### PR TITLE
chore: restore required CI with lockfile and codecov bumps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
         run: bundle exec rspec
       - name: Upload coverage to Codecov
         if: ${{ strategy.job-index == 0 }} # only run codecov on first run
-        uses: codecov/codecov-action@v6.0.1
+        uses: codecov/codecov-action@v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
         run: bundle exec rspec
       - name: Upload coverage to Codecov
         if: ${{ strategy.job-index == 0 }} # only run codecov on first run
-        uses: codecov/codecov-action@v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,7 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.21.1)
+    json (2.21.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     listen (3.10.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
     base64 (0.3.0)
     bigdecimal (4.1.1)
     builder (3.3.0)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     csv (3.3.5)
     cucumber (11.0.0)
       base64 (~> 0.2)
@@ -43,7 +43,7 @@ GEM
       reline (>= 0.3.8)
     diff-lcs (1.6.2)
     docile (1.4.1)
-    erb (6.0.2)
+    erb (6.0.4)
     ffi (1.17.4)
     fileutils (1.8.0)
     io-console (0.8.2)
@@ -52,7 +52,7 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.19.3)
+    json (2.21.1)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     listen (3.10.0)
@@ -211,4 +211,4 @@ DEPENDENCIES
   timecop (~> 0.9.10)
 
 BUNDLED WITH
-  4.0.6
+  4.0.12


### PR DESCRIPTION
## Summary

- Bump `codecov/codecov-action` from v6.0.1 to v7.0.0 so the Ruby 4.0 coverage upload stops failing GPG verification
- Bump `erb` to 6.0.4, `json` to 2.21.1, `concurrent-ruby` to 1.3.7, and Bundler to 4.0.12 so Security Audit (and ruby-head install) pass

Combines the lockfile changes from #281 with the Codecov bump from #291 so the required `CI Status` check can go green.

### Related Issues

- #281
- #291